### PR TITLE
Fix marked checkbox with ambiguous Markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ from public sources and replacing the online course videos over time. I like usi
     - [x] http://www.google.com/about/careers/lifeatgoogle/hiringprocess/
     - [x] http://steve-yegge.blogspot.com/2008/03/get-that-job-at-google.html
         - all the things he mentions that you need to know are listed below
-    - [x] (very dated) http://dondodge.typepad.com/the_next_big_thing/2010/09/how-to-get-a-job-at-google-interview-questions-hiring-process.html
+    - [x] _(very dated)_ http://dondodge.typepad.com/the_next_big_thing/2010/09/how-to-get-a-job-at-google-interview-questions-hiring-process.html
     - [x] http://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions
 
 - [x] Additional (not suggested by Google but I added):


### PR DESCRIPTION
This pull-request fixes bug in the Markdown parser used by GitHub to translate `[x]` into HTML checkboxes, the way it is currently written makes the transpiler believe that the text in between parenthesis is actually part of a Markdown link with this syntax `[title](href)` which makes me believe that the parser is taking `/\[x\][^(]+\([^)]+\)/` _(notice the pattern in between the braces and the parenthesis)_.

So instead of this:

- [x] _(very dated)_ http://dondodge.typepad.com/the_next_big_thing/2010/09/how-to-get-a-job-at-google-interview-questions-hiring-process.html

... it is rendering this:

- [x](very dated) http://dondodge.typepad.com/the_next_big_thing/2010/09/how-to-get-a-job-at-google-interview-questions-hiring-process.html