### PR TITLE
All links in README.md now open in new tab (Fix #2039)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > I originally created this as a short to-do list of study topics for becoming a software engineer,
 > but it grew to the large list you see today. After going through this study plan, [I got hired
-> as a Software Development Engineer at Amazon](https://startupnextdoor.com/ive-been-acquired-by-amazon/?src=ciu)!
+> as a <a href="https://startupnextdoor.com/ive-been-acquired-by-amazon/?src=ciu" target="_blank">Software Development Engineer at Amazon</a>!
 > You probably won't have to study as much as I did. Anyway, everything you need is here.
 >
-> I studied about 8-12 hours a day, for several months. This is my story: [Why I studied full-time for 8 months for a Google interview](https://medium.freecodecamp.org/why-i-studied-full-time-for-8-months-for-a-google-interview-cc662ce9bb13)
+> I studied about 8-12 hours a day, for several months. This is my story: <a href="https://medium.freecodecamp.org/why-i-studied-full-time-for-8-months-for-a-google-interview-cc662ce9bb13" target="_blank">Why I studied full-time for 8 months for a Google interview</a>
 >
 > **Please Note:** You won't need to study as much as I did. I wasted a lot of time on things I didn't need to know. More info about that is below. I'll help you get there without wasting your precious time.
 >
@@ -17,43 +17,42 @@
 <details>
 <summary>Translations:</summary>
 
-- [Bahasa Indonesia](translations/README-id.md)
-- [Bulgarian](translations/README-bg.md)
-- [Español](translations/README-es.md)
-- [German](translations/README-de.md)
-- [Japanese (日本語)](translations/README-ja.md)
-- [Marathi](translations/README-mr.md)
-- [Polish](translations/README-pl.md)
-- [Português Brasileiro](translations/README-ptbr.md)
-- [Russian](translations/README-ru.md)
-- [Tiếng Việt - Vietnamese](translations/README-vi.md)
-- [Urdu - اردو](translations/README-ur.md)
-- [Uzbek](translations/README-uz.md)
-- [বাংলা - Bangla](translations/README-bn.md)
-- [ខ្មែរ - Khmer](translations/README-kh.md)
-- [简体中文](translations/README-cn.md)
-- [繁體中文](translations/README-tw.md)
+- <a href="translations/README-id.md" target="_blank">Bahasa Indonesia</a>
+- <a href="translations/README-bg.md" target="_blank">Bulgarian</a>
+- <a href="translations/README-es.md" target="_blank">Español</a>
+- <a href="translations/README-de.md" target="_blank">German</a>
+- <a href="translations/README-ja.md" target="_blank">Japanese (日本語)</a>
+- <a href="translations/README-mr.md" target="_blank">Marathi</a>
+- <a href="translations/README-pl.md" target="_blank">Polish</a>
+- <a href="translations/README-ptbr.md" target="_blank">Português Brasileiro</a>
+- <a href="translations/README-ru.md" target="_blank">Russian</a>
+- <a href="translations/README-vi.md" target="_blank">Tiếng Việt - Vietnamese</a>
+- <a href="translations/README-ur.md" target="_blank">Urdu - اردو</a>
+- <a href="translations/README-uz.md" target="_blank">Uzbek</a>
+- <a href="translations/README-bn.md" target="_blank">বাংলা - Bangla</a>
+- <a href="translations/README-kh.md" target="_blank">ខ្មែរ - Khmer</a>
+- <a href="translations/README-cn.md" target="_blank">简体中文</a>
+- <a href="translations/README-tw.md" target="_blank">繁體中文</a>
 </details>
 
 <details>
 <summary>Translations in progress:</summary>
 
-- [Afrikaans](https://github.com/jwasham/coding-interview-university/issues/1164)
-- [Arabic](https://github.com/jwasham/coding-interview-university/issues/98)
-- [French](https://github.com/jwasham/coding-interview-university/issues/89)
-- [Greek](https://github.com/jwasham/coding-interview-university/issues/166)
-- [Italian](https://github.com/jwasham/coding-interview-university/issues/1030)
-- [Korean(한국어)](https://github.com/jwasham/coding-interview-university/issues/118)
-- [Malayalam](https://github.com/jwasham/coding-interview-university/issues/239)
-- [Persian - Farsi](https://github.com/jwasham/coding-interview-university/issues/186)
-- [Telugu](https://github.com/jwasham/coding-interview-university/issues/117)
-- [Thai](https://github.com/jwasham/coding-interview-university/issues/156)
-- [Turkish](https://github.com/jwasham/coding-interview-university/issues/90)
-- [Українська](https://github.com/jwasham/coding-interview-university/issues/106)
-- [עברית](https://github.com/jwasham/coding-interview-university/issues/82)
-- [हिन्दी](https://github.com/jwasham/coding-interview-university/issues/81)
+- <a href="https://github.com/jwasham/coding-interview-university/issues/1164" target="_blank">Afrikaans</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/98" target="_blank">Arabic</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/89" target="_blank">French</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/166" target="_blank">Greek</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/1030" target="_blank">Italian</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/118" target="_blank">Korean(한국어)</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/239" target="_blank">Malayalam</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/186" target="_blank">Persian - Farsi</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/117" target="_blank">Telugu</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/156" target="_blank">Thai</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/90" target="_blank">Turkish</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/106" target="_blank">Українська</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/82" target="_blank">עברית</a>
+- <a href="https://github.com/jwasham/coding-interview-university/issues/81" target="_blank">हिन्दी</a>
 </details>
-
 
 ## What is it?
 
@@ -66,11 +65,10 @@ This is my multi-month study plan for becoming a software engineer for a large c
 * Patience
 * Time
 
-Note this is a study plan for **software engineering**, not frontend engineering or full-stack development. There are really
-super roadmaps and coursework for those career paths elsewhere (see https://roadmap.sh/ for more info).
+Note this is a study plan for **software engineering**, not frontend engineering or full-stack development. There are really super roadmaps and coursework for those career paths elsewhere (see <a href="https://roadmap.sh/" target="_blank">roadmap.sh</a> for more info).
 
 There is a lot to learn in a university Computer Science program, but only knowing about 75% is good enough for an interview, so that's what I cover here.
-For a complete CS self-taught program, the resources for my study plan have been included in Kamran Ahmed's Computer Science Roadmap: https://roadmap.sh/computer-science
+For a complete CS self-taught program, the resources for my study plan have been included in Kamran Ahmed's <a href="https://roadmap.sh/computer-science" target="_blank">Computer Science Roadmap</a>.
 
 ---
 
@@ -221,7 +219,7 @@ It's a long plan. It may take you months. If you are familiar with a lot of this
 Everything below is an outline, and you should tackle the items in order from top to bottom.
 
 I'm using GitHub's special markdown flavor, including tasks lists to track progress.
-  - [More about GitHub-flavored markdown](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown)
+- <a href="https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown" target="_blank">More about GitHub-flavored markdown</a>
 
 ### If you don't want to use git
 
@@ -263,8 +261,8 @@ Create a new branch so you can check items like this, just put an x in the brack
 
 - Successful software engineers are smart, but many have an insecurity that they aren't smart enough.
 - The following videos may help you overcome this insecurity:
-    - [The myth of the Genius Programmer](https://www.youtube.com/watch?v=0SARbwvhupQ)
-    - [It's Dangerous to Go Alone: Battling the Invisible Monsters in Tech](https://www.youtube.com/watch?v=1i8ylq4j_EY)
+	- <a href="https://www.youtube.com/watch?v=0SARbwvhupQ" target="_blank">The myth of the Genius Programmer</a>
+    - <a href="https://www.youtube.com/watch?v=1i8ylq4j_EY" target="_blank">It's Dangerous to Go Alone: Battling the Invisible Monsters in Tech</a>
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -294,7 +292,7 @@ When I did the study plan, I used 2 languages for most of it: C and Python
     and algorithms in your bones. In higher-level languages like Python or Java, these are hidden from you. In day-to-day work, that's terrific,
     but when you're learning how these low-level data structures are built, it's great to feel close to the metal.
     - C is everywhere. You'll see examples in books, lectures, videos, *everywhere* while you're studying.
-    - [The C Programming Language, 2nd Edition](https://www.amazon.com/Programming-Language-Brian-W-Kernighan/dp/0131103628)
+    - <a href="https://www.amazon.com/Programming-Language-Brian-W-Kernighan/dp/0131103628" target="_blank">The C Programming Language, 2nd Edition</a>
         - This is a short book, but it will give you a great handle on the C language and if you practice it a little
             you'll quickly get proficient. Understanding C helps you understand how programs and memory work.
         - You don't need to go super deep in the book (or even finish it). Just get to where you're comfortable reading and writing in C.
@@ -303,12 +301,12 @@ When I did the study plan, I used 2 languages for most of it: C and Python
 This is my preference. You do what you like, of course.
 
 You may not need it, but here are some sites for learning a new language:
-- [Exercism](https://exercism.org/tracks)
-- [Codewars](http://www.codewars.com)
-- [HackerEarth](https://www.hackerearth.com/for-developers/)
-- [Scaler Topics (Java, C++)](https://www.scaler.com/topics/)
-- [Programiz PRO Community Challenges)](https://programiz.pro/)
-
+- <a href="https://exercism.org/tracks" target="_blank">Exercism</a>
+- <a href="http://www.codewars.com" target="_blank">Codewars</a>
+- <a href="https://www.hackerearth.com/for-developers/" target="_blank">HackerEarth</a>
+- <a href="https://www.scaler.com/topics/" target="_blank">Scaler Topics (Java, C++)</a>
+- <a href="https://programiz.pro/" target="_blank">Programiz PRO Community Challenges)</a>
+  
 ### For your Coding Interview
 
 You can use a language you are comfortable in to do the coding part of the interview, but for large companies, these are solid choices:
@@ -323,15 +321,15 @@ You could also use these, but read around first. There may be caveats:
 - Ruby
 
 Here is an article I wrote about choosing a language for the interview:
-[Pick One Language for the Coding Interview](https://startupnextdoor.com/important-pick-one-language-for-the-coding-interview/).
-This is the original article my post was based on: [Choosing a Programming Language for Interviews](https://web.archive.org/web/20210516054124/http://blog.codingforinterviews.com/best-programming-language-jobs/)
+<a href="https://startupnextdoor.com/important-pick-one-language-for-the-coding-interview/" target="_blank">Pick One Language for the Coding Interview</a>
+This is the original article my post was based on: <a href="https://web.archive.org/web/20210516054124/http://blog.codingforinterviews.com/best-programming-language-jobs/" target="_blank">Choosing a Programming Language for Interviews</a>
 
 You need to be very comfortable in the language and be knowledgeable.
 
 Read more about choices:
-- [Choose the Right Language for Your Coding Interview](http://www.byte-by-byte.com/choose-the-right-language-for-your-coding-interview/)
+- <a href="http://www.byte-by-byte.com/choose-the-right-language-for-your-coding-interview/" target="_blank">Choose the Right Language for Your Coding Interview</a>
 
-[See language-specific resources here](programming-language-resources.md)
+<a href="programming-language-resources.md" target="_blank">See language-specific resources here</a>
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -343,7 +341,7 @@ Just choose one, in a language that you will be comfortable with. You'll be doin
 
 ### Python
 
-- [Coding Interview Patterns: Nail Your Next Coding Interview](https://geni.us/q7svoz) (**Main Recommendation**)
+- <a href="https://geni.us/q7svoz" target="_blank">Coding Interview Patterns: Nail Your Next Coding Interview</a> (**Main Recommendation**)
     - An insider’s perspective on what interviewers are truly looking for and why.
     - 101 real coding interview problems with detailed solutions.
     - Intuitive explanations that guide you through each problem as if you were solving it in a live interview.
@@ -351,7 +349,7 @@ Just choose one, in a language that you will be comfortable with. You'll be doin
 
 ### C
 
-- [Algorithms in C, Parts 1-5 (Bundle), 3rd Edition](https://www.amazon.com/Algorithms-Parts-1-5-Bundle-Fundamentals/dp/0201756080)
+- <a href="https://www.amazon.com/Algorithms-Parts-1-5-Bundle-Fundamentals/dp/0201756080" target="_blank">Algorithms in C, Parts 1-5 (Bundle), 3rd Edition</a>
     - Fundamentals, Data Structures, Sorting, Searching, and Graph Algorithms
 
 ### Java
@@ -359,22 +357,22 @@ Just choose one, in a language that you will be comfortable with. You'll be doin
 Your choice:
 
 - Goodrich, Tamassia, Goldwasser
-    - [Data Structures and Algorithms in Java](https://www.amazon.com/Data-Structures-Algorithms-Michael-Goodrich/dp/1118771338/)
+  	- <a href="https://www.amazon.com/Data-Structures-Algorithms-Michael-Goodrich/dp/1118771338/" target="_blank">Data Structures and Algorithms in Java</a>
 - Sedgewick and Wayne:
-    - [Algorithms](https://www.amazon.com/Algorithms-4th-Robert-Sedgewick/dp/032157351X/)
+   	- <a href="https://www.amazon.com/Algorithms-4th-Robert-Sedgewick/dp/032157351X/" target="_blank">Algorithms</a>
     - Free Coursera course that covers the book (taught by the authors!):
-        - [Algorithms I](https://www.coursera.org/learn/algorithms-part1)
-        - [Algorithms II](https://www.coursera.org/learn/algorithms-part2)
-
+    	- <a href="https://www.coursera.org/learn/algorithms-part1" target="_blank">Algorithms I</a>
+	 	- <a href="https://www.coursera.org/learn/algorithms-part2" target="_blank">Algorithms II</a>
+   
 ### C++
 
 Your choice:
 
-- Goodrich, Tamassia, and Mount
-    - [Data Structures and Algorithms in C++, 2nd Edition](https://www.amazon.com/Data-Structures-Algorithms-Michael-Goodrich/dp/0470383275)
-- Sedgewick and Wayne
-    - [Algorithms in C++, Parts 1-4: Fundamentals, Data Structure, Sorting, Searching](https://www.amazon.com/Algorithms-Parts-1-4-Fundamentals-Structure/dp/0201350882/)
-    - [Algorithms in C++ Part 5: Graph Algorithms](https://www.amazon.com/Algorithms-Part-Graph-3rd-Pt-5/dp/0201361183/)
+- Goodrich, Tamassia, and Mount  
+    - <a href="https://www.amazon.com/Data-Structures-Algorithms-Michael-Goodrich/dp/0470383275" target="_blank">Data Structures and Algorithms in C++, 2nd Edition</a>  
+- Sedgewick and Wayne  
+    - <a href="https://www.amazon.com/Algorithms-Parts-1-4-Fundamentals-Structure/dp/0201350882/" target="_blank">Algorithms in C++, Parts 1-4: Fundamentals, Data Structure, Sorting, Searching</a>  
+    - <a href="https://www.amazon.com/Algorithms-Part-Graph-3rd-Pt-5/dp/0201361183/" target="_blank">Algorithms in C++ Part 5: Graph Algorithms</a>
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -382,24 +380,24 @@ Your choice:
 
 Here are some recommended books to supplement your learning.
 
-- [Coding Interview Patterns: Nail Your Next Coding Interview](https://geni.us/q7svoz)
+- <a href="https://geni.us/q7svoz" target="_blank">Coding Interview Patterns: Nail Your Next Coding Interview</a>
 
-- [Programming Interviews Exposed: Coding Your Way Through the Interview, 4th Edition](https://www.amazon.com/Programming-Interviews-Exposed-Through-Interview/dp/111941847X/)
+- <a href="https://www.amazon.com/Programming-Interviews-Exposed-Through-Interview/dp/111941847X/" target="_blank">Programming Interviews Exposed: Coding Your Way Through the Interview, 4th Edition</a>
     - Answers in C++ and Java
     - This is a good warm-up for Cracking the Coding Interview
     - Not too difficult. Most problems may be easier than what you'll see in an interview (from what I've read)
 
-- [Cracking the Coding Interview, 6th Edition](http://www.amazon.com/Cracking-Coding-Interview-6th-Programming/dp/0984782850/)
+- <a href="http://www.amazon.com/Cracking-Coding-Interview-6th-Programming/dp/0984782850/" target="_blank" rel="noopener noreferrer">Cracking the Coding Interview, 6th Edition</a>
     - answers in Java
 
 ### If you have tons of extra time:
 
 Choose one:
 
-- [Elements of Programming Interviews (C++ version)](https://www.amazon.com/Elements-Programming-Interviews-Insiders-Guide/dp/1479274836)
-- [Elements of Programming Interviews in Python](https://www.amazon.com/Elements-Programming-Interviews-Python-Insiders/dp/1537713949/)
-- [Elements of Programming Interviews (Java version)](https://www.amazon.com/Elements-Programming-Interviews-Java-Insiders/dp/1517435803/)
-        - [Companion Project - Method Stub and Test Cases for Every Problem in the Book](https://github.com/gardncl/elements-of-programming-interviews)
+- <a href="https://www.amazon.com/Elements-Programming-Interviews-Insiders-Guide/dp/1479274836" target="_blank" rel="noopener noreferrer">Elements of Programming Interviews (C++ version)</a>
+- <a href="https://www.amazon.com/Elements-Programming-Interviews-Python-Insiders/dp/1537713949/" target="_blank" rel="noopener noreferrer">Elements of Programming Interviews in Python</a>
+- <a href="https://www.amazon.com/Elements-Programming-Interviews-Java-Insiders/dp/1517435803/" target="_blank" rel="noopener noreferrer">Elements of Programming Interviews (Java version)</a>
+        - <a href="https://github.com/gardncl/elements-of-programming-interviews" target="_blank" rel="noopener noreferrer">Companion Project - Method Stub and Test Cases for Every Problem in the Book</a>
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -416,7 +414,7 @@ through my notes and making flashcards, so I could review. I didn't need all of 
 
 Please, read so you won't make my mistakes:
 
-[Retaining Computer Science Knowledge](https://startupnextdoor.com/retaining-computer-science-knowledge/).
+- <a href="https://startupnextdoor.com/retaining-computer-science-knowledge/" target="_blank">Retaining Computer Science Knowledge</a>.
 
 ### 2. Use Flashcards
 
@@ -425,13 +423,13 @@ Each card has a different formatting. I made a mobile-first website, so I could 
 
 Make your own for free:
 
-- [Flashcards site repo](https://github.com/jwasham/computer-science-flash-cards)
+- <a href="https://github.com/jwasham/computer-science-flash-cards" target="_blank">Flashcards site repo</a>
 
 **I DON'T RECOMMEND using my flashcards.** There are too many and most of them are trivia that you don't need.
 
 But if you don't want to listen to me, here you go:
-- [My flash cards database (1200 cards)](https://github.com/jwasham/computer-science-flash-cards/blob/main/cards-jwasham.db):
-- [My flash cards database (extreme - 1800 cards)](https://github.com/jwasham/computer-science-flash-cards/blob/main/cards-jwasham-extreme.db):
+- <a href="https://github.com/jwasham/computer-science-flash-cards/blob/main/cards-jwasham.db" target="_blank">My flash cards database (1200 cards)</a>:
+- <a href="https://github.com/jwasham/computer-science-flash-cards/blob/main/cards-jwasham-extreme.db" target="_blank">My flash cards database (extreme - 1800 cards)</a>:
 
 Keep in mind I went overboard and have cards covering everything from assembly language and Python trivia to machine learning and statistics.
 It's way too much for what's required.
@@ -440,11 +438,11 @@ It's way too much for what's required.
 same card and answer it several times correctly before you really know it. Repetition will put that knowledge deeper in
 your brain.
 
-An alternative to using my flashcard site is [Anki](http://ankisrs.net/), which has been recommended to me numerous times.
+An alternative to using my flashcard site is <a href="http://ankisrs.net/" target="_blank">Anki</a>, which has been recommended to me numerous times.
 It uses a repetition system to help you remember. It's user-friendly, available on all platforms, and has a cloud sync system.
 It costs $25 on iOS but is free on other platforms.
 
-My flashcard database in Anki format: https://ankiweb.net/shared/info/25173560 (thanks [@xiewenya](https://github.com/xiewenya)).
+My flashcard database in Anki format: https://ankiweb.net/shared/info/25173560 (thanks <a href="https://github.com/xiewenya" target="_blank">@xiewenya</a>).
 
 Some students have mentioned formatting issues with white space that can be fixed by doing the following: open the deck, edit the card, click cards, select the "styling" radio button, and add the member "white-space: pre;" to the card class.
 
@@ -494,9 +492,9 @@ Each day, take the next subject in the list, watch some videos about that subjec
 of that data structure or algorithm in the language you chose for this course.
 
 You can see my code here:
- - [C](https://github.com/jwasham/practice-c)
- - [C++](https://github.com/jwasham/practice-cpp)
- - [Python](https://github.com/jwasham/practice-python)
+- <a href="https://github.com/jwasham/practice-c" target="_blank">C</a>
+- <a href="https://github.com/jwasham/practice-cpp" target="_blank">C++</a>
+- <a href="https://github.com/jwasham/practice-python" target="_blank">Python</a>
 
 You don't need to memorize every algorithm. You just need to be able to understand it enough to be able to write your own implementation.
 
@@ -518,7 +516,7 @@ Why you need to practice doing programming problems:
 
 There is a great intro for methodical, communicative problem-solving in an interview. You'll get this from the programming
 interview books, too, but I found this outstanding:
-[Algorithm design canvas](http://www.hiredintech.com/algorithm-design/)
+<a href="http://www.hiredintech.com/algorithm-design/" target="_blank">Algorithm design canvas</a>
 
 Write code on a whiteboard or paper, not a computer. Test with some sample inputs. Then type it and test it out on a computer.
 
@@ -537,30 +535,30 @@ Gets messy quickly. **I use a pencil and eraser.**
 Don't forget your key coding interview books [here](#interview-prep-books).
 
 Solving Problems:
-- [How to Find a Solution](https://www.topcoder.com/thrive/articles/How%20To%20Find%20a%20Solution)
-- [How to Dissect a Topcoder Problem Statement](https://www.topcoder.com/thrive/articles/How%20To%20Dissect%20a%20Topcoder%20Problem%20Statement%20Content)
+- <a href="https://www.topcoder.com/thrive/articles/How%20To%20Find%20a%20Solution" target="_blank">How to Find a Solution</a>
+- <a href="https://www.topcoder.com/thrive/articles/How%20To%20Dissect%20a%20Topcoder%20Problem%20Statement%20Content" target="_blank">How to Dissect a Topcoder Problem Statement</a>
 
 Coding Interview Question Videos:
-- [IDeserve (88 videos)](https://www.youtube.com/playlist?list=PLamzFoFxwoNjPfxzaWqs7cZGsPYy0x_gI)
-- [Tushar Roy (5 playlists)](https://www.youtube.com/user/tusharroy2525/playlists?shelf_id=2&view=50&sort=dd)
+- <a href="https://www.youtube.com/playlist?list=PLamzFoFxwoNjPfxzaWqs7cZGsPYy0x_gI" target="_blank">IDeserve (88 videos)</a>
+- <a href="https://www.youtube.com/user/tusharroy2525/playlists?shelf_id=2&view=50&sort=dd" target="_blank">Tushar Roy (5 playlists)</a>  
     - Super for walkthroughs of problem solutions
-- [Nick White - LeetCode Solutions (187 Videos)](https://www.youtube.com/playlist?list=PLU_sdQYzUj2keVENTP0a5rdykRSgg9Wp-)
-    - Good explanations of the solution and the code
+- <a href="https://www.youtube.com/playlist?list=PLU_sdQYzUj2keVENTP0a5rdykRSgg9Wp-" target="_blank">Nick White - LeetCode Solutions (187 Videos)</a>  
+    - Good explanations of the solution and the code  
     - You can watch several in a short time
-- [FisherCoder - LeetCode Solutions](https://youtube.com/FisherCoder)
+- <a href="https://youtube.com/FisherCoder" target="_blank">FisherCoder - LeetCode Solutions</a>
 
 Challenge/Practice sites:
-- [LeetCode](https://leetcode.com/)
+- <a href="https://leetcode.com/" target="_blank">LeetCode</a>
     - My favorite coding problem site. It's worth the subscription money for the 1-2 months you'll likely be preparing.
     - See Nick White and FisherCoder Videos above for code walk-throughs.
-- [HackerRank](https://www.hackerrank.com/)
-- [TopCoder](https://www.topcoder.com/)
-- [Codeforces](https://codeforces.com/)
-- [Codility](https://codility.com/programmers/)
-- [Geeks for Geeks](https://practice.geeksforgeeks.org/explore/?page=1)
-- [AlgoExpert](https://www.algoexpert.io/product)
+- <a href="https://www.hackerrank.com/" target="_blank">HackerRank</a>
+- <a href="https://www.topcoder.com/" target="_blank">TopCoder</a>
+- <a href="https://codeforces.com/" target="_blank">Codeforces</a>
+- <a href="https://codility.com/programmers/" target="_blank">Codility</a>
+- <a href="https://practice.geeksforgeeks.org/explore/?page=1" target="_blank">Geeks for Geeks</a>
+- <a href="https://www.algoexpert.io/product" target="_blank">AlgoExpert</a>
     - Created by Google engineers, this is also an excellent resource to hone your skills.
-- [Project Euler](https://projecteuler.net/)
+- <a href="https://projecteuler.net/" target="_blank">Project Euler</a>
     - very math-focused, and not really suited for coding interviews
 
 **[⬆ back to top](#table-of-contents)**
@@ -577,17 +575,17 @@ But don't forget to do coding problems from above while you learn!
 - There are a lot of videos here. Just watch enough until you understand it. You can always come back and review.
 - Don't worry if you don't understand all the math behind it.
 - You just need to understand how to express the complexity of an algorithm in terms of Big-O.
-- [ ] [Harvard CS50 - Asymptotic Notation (video)](https://www.youtube.com/watch?v=iOq5kSKqeR4)
-- [ ] [Big O Notations (general quick tutorial) (video)](https://www.youtube.com/watch?v=V6mKVRU1evU)
-- [ ] [Big O Notation (and Omega and Theta) - best mathematical explanation (video)](https://www.youtube.com/watch?v=ei-A_wy5Yxw&index=2&list=PL1BaGV1cIH4UhkL8a9bJGG356covJ76qN)
-- [ ] [Skiena (video)](https://www.youtube.com/watch?v=z1mkCe3kVUA)
-- [ ] [UC Berkeley Big O (video)](https://archive.org/details/ucberkeley_webcast_VIS4YDpuP98)
-- [ ] [Amortized Analysis (video)](https://www.youtube.com/watch?v=B3SpQZaAZP4&index=10&list=PL1BaGV1cIH4UhkL8a9bJGG356covJ76qN)
+- [ ] <a href="https://www.youtube.com/watch?v=iOq5kSKqeR4" target="_blank">Harvard CS50 - Asymptotic Notation (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=V6mKVRU1evU" target="_blank">Big O Notations (general quick tutorial) (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=ei-A_wy5Yxw&index=2&list=PL1BaGV1cIH4UhkL8a9bJGG356covJ76qN" target="_blank">Big O Notation (and Omega and Theta) - best mathematical explanation (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=z1mkCe3kVUA" target="_blank">Skiena (video)</a>
+- [ ] <a href="https://archive.org/details/ucberkeley_webcast_VIS4YDpuP98" target="_blank">UC Berkeley Big O (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=B3SpQZaAZP4&index=10&list=PL1BaGV1cIH4UhkL8a9bJGG356covJ76qN" target="_blank">Amortized Analysis (video)</a>
 - [ ] TopCoder (includes recurrence relations and master theorem):
-    - [Computational Complexity: Section 1](https://www.topcoder.com/thrive/articles/Computational%20Complexity%20part%20one)
-    - [Computational Complexity: Section 2](https://www.topcoder.com/thrive/articles/Computational%20Complexity%20part%20two)
-- [ ] [Cheat sheet](http://bigocheatsheet.com/)
-- [ ] [[Review] Analyzing Algorithms (playlist) in 18 minutes (video)](https://www.youtube.com/playlist?list=PL9xmBV_5YoZMxejjIyFHWa-4nKg6sdoIv)
+    - <a href="https://www.topcoder.com/thrive/articles/Computational%20Complexity%20part%20one" target="_blank">Computational Complexity: Section 1</a>
+    - <a href="https://www.topcoder.com/thrive/articles/Computational%20Complexity%20part%20two" target="_blank">Computational Complexity: Section 2</a>
+- [ ] <a href="http://bigocheatsheet.com/" target="_blank">Cheat sheet</a>
+- [ ] <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZMxejjIyFHWa-4nKg6sdoIv" target="_blank">[Review] Analyzing Algorithms (playlist) in 18 minutes (video)</a>
 
 Well, that's about enough of that.
 
@@ -600,11 +598,12 @@ if you can identify the runtime complexity of different algorithms. It's a super
 
 - ### Arrays
     - [ ] About Arrays:
-    	- [Arrays CS50 Harvard University](https://www.youtube.com/watch?v=tI_tIZFyKBw&t=3009s)
-        - [Arrays (video)](https://www.coursera.org/lecture/data-structures/arrays-OsBSF)
-        - [UC Berkeley CS61B - Linear and Multi-Dim Arrays (video)](https://archive.org/details/ucberkeley_webcast_Wp8oiO_CZZE) (Start watching from 15m 32s)
-        - [Dynamic Arrays (video)](https://www.coursera.org/lecture/data-structures/dynamic-arrays-EwbnV)
-        - [Jagged Arrays (video)](https://www.youtube.com/watch?v=1jtrQqYpt7g)
+    	- <a href="https://www.youtube.com/watch?v=tI_tIZFyKBw&t=3009s" target="_blank">Arrays CS50 Harvard University</a>
+    	- <a href="https://www.coursera.org/lecture/data-structures/arrays-OsBSF" target="_blank">Arrays (video)</a>
+    	- <a href="https://archive.org/details/ucberkeley_webcast_Wp8oiO_CZZE" target="_blank">UC Berkeley CS61B - Linear and Multi-Dim Arrays (video)</a> (Start watching from 15m 32s)
+    	- <a href="https://www.coursera.org/lecture/data-structures/dynamic-arrays-EwbnV" target="_blank">Dynamic Arrays (video)</a>
+    	- <a href="https://www.youtube.com/watch?v=1jtrQqYpt7g" target="_blank">Jagged Arrays (video)</a>
+
     - [ ] Implement a vector (mutable array with automatic resizing):
         - [ ] Practice coding using arrays and pointers, and pointer math to jump to an index instead of using indexing.
         - [ ] New raw data array with allocated memory
@@ -633,21 +632,21 @@ if you can identify the runtime complexity of different algorithms. It's a super
 
 - ### Linked Lists
     - [ ] Description:
-    	- [ ] [Linked Lists CS50 Harvard University](https://www.youtube.com/watch?v=2T-A_GFuoTo&t=650s) - this builds the intuition.
-        - [ ] [Singly Linked Lists (video)](https://www.coursera.org/lecture/data-structures/singly-linked-lists-kHhgK)
-        - [ ] [CS 61B - Linked Lists 1 (video)](https://archive.org/details/ucberkeley_webcast_htzJdKoEmO0)
-        - [ ] [CS 61B - Linked Lists 2 (video)](https://archive.org/details/ucberkeley_webcast_-c4I3gFYe3w)
-        - [ ] [[Review] Linked lists in 4 minutes (video)](https://youtu.be/F8AbOfQwl1c)
-    - [ ] [C Code (video)](https://www.youtube.com/watch?v=QN6FPiD0Gzo)
+    	- [ ] <a href="https://www.youtube.com/watch?v=2T-A_GFuoTo&t=650s" target="_blank">Linked Lists CS50 Harvard University</a> - this builds the intuition.
+        - [ ] <a href="https://www.coursera.org/lecture/data-structures/singly-linked-lists-kHhgK" target="_blank">Singly Linked Lists (video)</a>
+        - [ ] <a href="https://archive.org/details/ucberkeley_webcast_htzJdKoEmO0" target="_blank">CS 61B - Linked Lists 1 (video)</a>
+        - [ ] <a href="https://archive.org/details/ucberkeley_webcast_-c4I3gFYe3w" target="_blank">CS 61B - Linked Lists 2 (video)</a>
+        - [ ] <a href="https://youtu.be/F8AbOfQwl1c" target="_blank">[Review] Linked lists in 4 minutes (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=QN6FPiD0Gzo" target="_blank">C Code (video)</a>  
             - not the whole video, just portions about Node struct and memory allocation
     - [ ] Linked List vs Arrays:
-        - [Core Linked Lists Vs Arrays (video)](https://www.coursera.org/lecture/data-structures-optimizing-performance/core-linked-lists-vs-arrays-rjBs9)
-        - [In The Real World Linked Lists Vs Arrays (video)](https://www.coursera.org/lecture/data-structures-optimizing-performance/in-the-real-world-lists-vs-arrays-QUaUd)
-    - [ ] [Why you should avoid linked lists (video)](https://www.youtube.com/watch?v=YQs6IC-vgmo)
-    - [ ] Gotcha: you need pointer to pointer knowledge:
-        (for when you pass a pointer to a function that may change the address where that pointer points)
-        This page is just to get a grasp on ptr to ptr. I don't recommend this list traversal style. Readability and maintainability suffer due to cleverness.
-        - [Pointers to Pointers](https://www.eskimo.com/~scs/cclass/int/sx8.html)
+        - [ ] <a href="https://www.coursera.org/lecture/data-structures-optimizing-performance/core-linked-lists-vs-arrays-rjBs9" target="_blank">Core Linked Lists Vs Arrays (video)</a>
+        - [ ] <a href="https://www.coursera.org/lecture/data-structures-optimizing-performance/in-the-real-world-lists-vs-arrays-QUaUd" target="_blank">In The Real World Linked Lists Vs Arrays (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=YQs6IC-vgmo" target="_blank">Why you should avoid linked lists (video)</a>
+    - [ ] Gotcha: you need pointer to pointer knowledge:  
+        (for when you pass a pointer to a function that may change the address where that pointer points)  
+        This page is just to get a grasp on ptr to ptr. I don't recommend this list traversal style. Readability and maintainability suffer due to cleverness.  
+        - [ ] <a href="https://www.eskimo.com/~scs/cclass/int/sx8.html" target="_blank">Pointers to Pointers</a>
     - [ ] Implement (I did with tail pointer & without):
         - [ ] size() - returns the number of data elements in the list
         - [ ] empty() - bool returns true if empty
@@ -664,18 +663,18 @@ if you can identify the runtime complexity of different algorithms. It's a super
         - [ ] reverse() - reverses the list
         - [ ] remove_value(value) - removes the first item in the list with this value
     - [ ] Doubly-linked List
-        - [Description (video)](https://www.coursera.org/lecture/data-structures/doubly-linked-lists-jpGKD)
+  		- <a href="https://www.coursera.org/lecture/data-structures/doubly-linked-lists-jpGKD" target="_blank">Description (video)</a>
         - No need to implement
 
 - ### Stack
-    - [ ] [Stacks (video)](https://www.coursera.org/lecture/data-structures/stacks-UdKzQ)
-    - [ ] [[Review] Stacks in 3 minutes (video)](https://youtu.be/KcT3aVgrrpU)
+    - [ ] <a href="https://www.coursera.org/lecture/data-structures/stacks-UdKzQ" target="_blank">Stacks (video)</a>
+    - [ ] <a href="https://youtu.be/KcT3aVgrrpU" target="_blank">[Review] Stacks in 3 minutes (video)</a>
     - [ ] Will not implement. Implementing with the array is trivial
 
 - ### Queue
-    - [ ] [Queue (video)](https://www.coursera.org/lecture/data-structures/queues-EShpq)
-    - [ ] [Circular buffer/FIFO](https://en.wikipedia.org/wiki/Circular_buffer)
-    - [ ] [[Review] Queues in 3 minutes (video)](https://youtu.be/D6gu-_tmEpQ)
+    - [ ] <a href="https://www.coursera.org/lecture/data-structures/queues-EShpq" target="_blank">Queue (video)</a>
+    - [ ] <a href="https://en.wikipedia.org/wiki/Circular_buffer" target="_blank">Circular buffer/FIFO</a>
+    - [ ] <a href="https://youtu.be/D6gu-_tmEpQ" target="_blank">[Review] Queues in 3 minutes (video)</a>
     - [ ] Implement using linked-list, with tail pointer:
         - enqueue(value) - adds value at a position at the tail
         - dequeue() - returns value and removes least recently added element (front)
@@ -694,22 +693,22 @@ if you can identify the runtime complexity of different algorithms. It's a super
 
 - ### Hash table
     - [ ] Videos:
-        - [ ] [Hashing with Chaining (video)](https://www.youtube.com/watch?v=0M_kIqhwbFo&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=8)
-        - [ ] [Table Doubling, Karp-Rabin (video)](https://www.youtube.com/watch?v=BRO7mVIFt08&index=9&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb)
-        - [ ] [Open Addressing, Cryptographic Hashing (video)](https://www.youtube.com/watch?v=rvdJDijO2Ro&index=10&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb)
-        - [ ] [PyCon 2010: The Mighty Dictionary (video)](https://www.youtube.com/watch?v=C4Kc8xzcA68)
-        - [ ] [PyCon 2017: The Dictionary Even Mightier (video)](https://www.youtube.com/watch?v=66P5FMkWoVU)
-        - [ ] [(Advanced) Randomization: Universal & Perfect Hashing (video)](https://www.youtube.com/watch?v=z0lJ2k0sl1g&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=11)
-        - [ ] [(Advanced) Perfect hashing (video)](https://www.youtube.com/watch?v=N0COwN14gt0&list=PL2B4EEwhKD-NbwZ4ezj7gyc_3yNrojKM9&index=4)
-        - [ ] [[Review] Hash tables in 4 minutes (video)](https://youtu.be/knV86FlSXJ8)
+        - [ ] <a href="https://www.youtube.com/watch?v=0M_kIqhwbFo&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=8" target="_blank" rel="noopener noreferrer">Hashing with Chaining (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=BRO7mVIFt08&index=9&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb" target="_blank" rel="noopener noreferrer">Table Doubling, Karp-Rabin (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=rvdJDijO2Ro&index=10&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb" target="_blank" rel="noopener noreferrer">Open Addressing, Cryptographic Hashing (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=C4Kc8xzcA68" target="_blank" rel="noopener noreferrer">PyCon 2010: The Mighty Dictionary (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=66P5FMkWoVU" target="_blank" rel="noopener noreferrer">PyCon 2017: The Dictionary Even Mightier (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=z0lJ2k0sl1g&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=11" target="_blank" rel="noopener noreferrer">(Advanced) Randomization: Universal & Perfect Hashing (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=N0COwN14gt0&list=PL2B4EEwhKD-NbwZ4ezj7gyc_3yNrojKM9&index=4" target="_blank" rel="noopener noreferrer">(Advanced) Perfect hashing (video)</a>
+        - [ ] <a href="https://youtu.be/knV86FlSXJ8" target="_blank" rel="noopener noreferrer">[Review] Hash tables in 4 minutes (video)</a>
 
-    - [ ] Online Courses:
-        - [ ] [Core Hash Tables (video)](https://www.coursera.org/lecture/data-structures-optimizing-performance/core-hash-tables-m7UuP)
-        - [ ] [Data Structures (video)](https://www.coursera.org/learn/data-structures/home/week/4)
-        - [ ] [Phone Book Problem (video)](https://www.coursera.org/lecture/data-structures/phone-book-problem-NYZZP)
-        - [ ] distributed hash tables:
-            - [Instant Uploads And Storage Optimization In Dropbox (video)](https://www.coursera.org/lecture/data-structures/instant-uploads-and-storage-optimization-in-dropbox-DvaIb)
-            - [Distributed Hash Tables (video)](https://www.coursera.org/lecture/data-structures/distributed-hash-tables-tvH8H)
+	- [ ] Online Courses:
+	    - [ ] <a href="https://www.coursera.org/lecture/data-structures-optimizing-performance/core-hash-tables-m7UuP" target="_blank" rel="noopener noreferrer">Core Hash Tables (video)</a>
+	    - [ ] <a href="https://www.coursera.org/learn/data-structures/home/week/4" target="_blank" rel="noopener noreferrer">Data Structures (video)</a>
+	    - [ ] <a href="https://www.coursera.org/lecture/data-structures/phone-book-problem-NYZZP" target="_blank" rel="noopener noreferrer">Phone Book Problem (video)</a>
+	    - [ ] distributed hash tables:
+	        - [ ] <a href="https://www.coursera.org/lecture/data-structures/instant-uploads-and-storage-optimization-in-dropbox-DvaIb" target="_blank" rel="noopener noreferrer">Instant Uploads And Storage Optimization In Dropbox (video)</a>
+	        - [ ] <a href="https://www.coursera.org/lecture/data-structures/distributed-hash-tables-tvH8H" target="_blank" rel="noopener noreferrer">Distributed Hash Tables (video)</a>
 
     - [ ] Implement with array using linear probing
         - hash(k, m) - m is the size of the hash table
@@ -723,51 +722,52 @@ if you can identify the runtime complexity of different algorithms. It's a super
 ## More Knowledge
 
 - ### Binary search
-    - [ ] [Binary Search (video)](https://www.youtube.com/watch?v=D5SrAga1pno)
-    - [ ] [Binary Search (video)](https://www.khanacademy.org/computing/computer-science/algorithms/binary-search/a/binary-search)
-    - [ ] [detail](https://www.topcoder.com/thrive/articles/Binary%20Search)
-    - [ ] [blueprint](https://leetcode.com/discuss/general-discussion/786126/python-powerful-ultimate-binary-search-template-solved-many-problems)
-    - [ ] [[Review] Binary search in 4 minutes (video)](https://youtu.be/fDKIpRe8GW4)
+    - [ ] <a href="https://www.youtube.com/watch?v=D5SrAga1pno" target="_blank">Binary Search (video)</a>
+    - [ ] <a href="https://www.khanacademy.org/computing/computer-science/algorithms/binary-search/a/binary-search" target="_blank">Binary Search (video)</a>
+    - [ ] <a href="https://www.topcoder.com/thrive/articles/Binary%20Search" target="_blank">detail</a>
+    - [ ] <a href="https://leetcode.com/discuss/general-discussion/786126/python-powerful-ultimate-binary-search-template-solved-many-problems" target="_blank">blueprint</a>
+    - [ ] <a href="https://youtu.be/fDKIpRe8GW4" target="_blank">[Review] Binary search in 4 minutes (video)</a>
     - [ ] Implement:
         - binary search (on a sorted array of integers)
         - binary search using recursion
 
 - ### Bitwise operations
-    - [ ] [Bits cheat sheet](https://github.com/jwasham/coding-interview-university/blob/main/extras/cheat%20sheets/bits-cheat-sheet.pdf)
+    - [ ] <a href="https://github.com/jwasham/coding-interview-university/blob/main/extras/cheat%20sheets/bits-cheat-sheet.pdf" target="_blank">Bits cheat sheet</a>
         - you should know many of the powers of 2 from (2^1 to 2^16 and 2^32)
     - [ ] Get a really good understanding of manipulating bits with: &, |, ^, ~, >>, <<
-        - [ ] [words](https://en.wikipedia.org/wiki/Word_(computer_architecture))
-        - [ ] Good intro:
-            [Bit Manipulation (video)](https://www.youtube.com/watch?v=7jkIUgLC29I)
-        - [ ] [C Programming Tutorial 2-10: Bitwise Operators (video)](https://www.youtube.com/watch?v=d0AwjSpNXR0)
-        - [ ] [Bit Manipulation](https://en.wikipedia.org/wiki/Bit_manipulation)
-        - [ ] [Bitwise Operation](https://en.wikipedia.org/wiki/Bitwise_operation)
-        - [ ] [Bithacks](https://graphics.stanford.edu/~seander/bithacks.html)
-        - [ ] [The Bit Twiddler](https://bits.stephan-brumme.com/)
-        - [ ] [The Bit Twiddler Interactive](https://bits.stephan-brumme.com/interactive.html)
-        - [ ] [Bit Hacks (video)](https://www.youtube.com/watch?v=ZusiKXcz_ac)
-		- [ ] [Practice Operations](https://pconrad.github.io/old_pconrad_cs16/topics/bitOps/)
-    - [ ] 2s and 1s complement
-        - [Binary: Plusses & Minuses (Why We Use Two's Complement) (video)](https://www.youtube.com/watch?v=lKTsv6iVxV4)
-        - [1s Complement](https://en.wikipedia.org/wiki/Ones%27_complement)
-        - [2s Complement](https://en.wikipedia.org/wiki/Two%27s_complement)
-    - [ ] Count set bits
-        - [4 ways to count bits in a byte (video)](https://youtu.be/Hzuzo9NJrlc)
-        - [Count Bits](https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan)
-        - [How To Count The Number Of Set Bits In a 32 Bit Integer](http://stackoverflow.com/questions/109023/how-to-count-the-number-of-set-bits-in-a-32-bit-integer)
-    - [ ] Swap values:
-        - [Swap](https://bits.stephan-brumme.com/swap.html)
-    - [ ] Absolute value:
-        - [Absolute Integer](https://bits.stephan-brumme.com/absInteger.html)
-
+        - [ ] <a href="https://en.wikipedia.org/wiki/Word_(computer_architecture)" target="_blank">words</a>
+        - [ ] Good intro:  
+            <a href="https://www.youtube.com/watch?v=7jkIUgLC29I" target="_blank">Bit Manipulation (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=d0AwjSpNXR0" target="_blank">C Programming Tutorial 2-10: Bitwise Operators (video)</a>
+        - [ ] <a href="https://en.wikipedia.org/wiki/Bit_manipulation" target="_blank">Bit Manipulation</a>
+        - [ ] <a href="https://en.wikipedia.org/wiki/Bitwise_operation" target="_blank">Bitwise Operation</a>
+        - [ ] <a href="https://graphics.stanford.edu/~seander/bithacks.html" target="_blank">Bithacks</a>
+        - [ ] <a href="https://bits.stephan-brumme.com/" target="_blank">The Bit Twiddler</a>
+        - [ ] <a href="https://bits.stephan-brumme.com/interactive.html" target="_blank">The Bit Twiddler Interactive</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=ZusiKXcz_ac" target="_blank">Bit Hacks (video)</a>
+	
+	- [ ] <a href="https://pconrad.github.io/old_pconrad_cs16/topics/bitOps/" target="_blank">Practice Operations</a>
+	    - [ ] 2s and 1s complement
+	        - <a href="https://www.youtube.com/watch?v=lKTsv6iVxV4" target="_blank">Binary: Plusses & Minuses (Why We Use Two's Complement) (video)</a>
+	        - <a href="https://en.wikipedia.org/wiki/Ones%27_complement" target="_blank">1s Complement</a>
+	        - <a href="https://en.wikipedia.org/wiki/Two%27s_complement" target="_blank">2s Complement</a>
+	    - [ ] Count set bits
+	        - <a href="https://youtu.be/Hzuzo9NJrlc" target="_blank">4 ways to count bits in a byte (video)</a>
+	        - <a href="https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan" target="_blank">Count Bits</a>
+	        - <a href="http://stackoverflow.com/questions/109023/how-to-count-the-number-of-set-bits-in-a-32-bit-integer" target="_blank">How To Count The Number Of Set Bits In a 32 Bit Integer</a>
+	    - [ ] Swap values:
+	        - <a href="https://bits.stephan-brumme.com/swap.html" target="_blank">Swap</a>
+	    - [ ] Absolute value:
+	        - <a href="https://bits.stephan-brumme.com/absInteger.html" target="_blank">Absolute Integer</a>
+		
 **[⬆ back to top](#table-of-contents)**
 
 ## Trees
 
 - ### Trees - Intro
-    - [ ] [Intro to Trees (video)](https://www.coursera.org/lecture/data-structures/trees-95qda)
-    - [ ] [Tree Traversal (video)](https://www.coursera.org/lecture/data-structures/tree-traversal-fr51b)
-    - [ ] [BFS(breadth-first search) and DFS(depth-first search) (video)](https://www.youtube.com/watch?v=uWL6FJhq5fM)
+    - [ ] <a href="https://www.coursera.org/lecture/data-structures/trees-95qda" target="_blank">Intro to Trees (video)</a>
+    - [ ] <a href="https://www.coursera.org/lecture/data-structures/tree-traversal-fr51b" target="_blank">Tree Traversal (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=uWL6FJhq5fM" target="_blank">BFS(breadth-first search) and DFS(depth-first search) (video)</a>
         - BFS notes:
            - level order (BFS, using queue)
            - time complexity: O(n)
@@ -780,54 +780,55 @@ if you can identify the runtime complexity of different algorithms. It's a super
             - inorder (DFS: left, self, right)
             - postorder (DFS: left, right, self)
             - preorder (DFS: self, left, right)
-    - [ ] [[Review] Breadth-first search in 4 minutes (video)](https://youtu.be/HZ5YTanv5QE)
-    - [ ] [[Review] Depth-first search in 4 minutes (video)](https://youtu.be/Urx87-NMm6c)
-    - [ ] [[Review] Tree Traversal (playlist) in 11 minutes (video)](https://www.youtube.com/playlist?list=PL9xmBV_5YoZO1JC2RgEi04nLy6D-rKk6b)
+	- [ ] <a href="https://youtu.be/HZ5YTanv5QE" target="_blank">[Review] Breadth-first search in 4 minutes (video)</a>
+	- [ ] <a href="https://youtu.be/Urx87-NMm6c" target="_blank">[Review] Depth-first search in 4 minutes (video)</a>
+	- [ ] <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZO1JC2RgEi04nLy6D-rKk6b" target="_blank">[Review] Tree Traversal (playlist) in 11 minutes (video)</a>
+
 
 - ### Binary search trees: BSTs
-    - [ ] [Binary Search Tree Review (video)](https://www.youtube.com/watch?v=x6At0nzX92o&index=1&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6)
-    - [ ] [Introduction (video)](https://www.coursera.org/learn/data-structures/lecture/E7cXP/introduction)
-    - [ ] [MIT (video)](https://www.youtube.com/watch?v=76dhtgZt38A&ab_channel=MITOpenCourseWare)
+    - [ ] <a href="https://www.youtube.com/watch?v=x6At0nzX92o&index=1&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6" target="_blank" rel="noopener noreferrer">Binary Search Tree Review (video)</a>
+    - [ ] <a href="https://www.coursera.org/learn/data-structures/lecture/E7cXP/introduction" target="_blank" rel="noopener noreferrer">Introduction (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=76dhtgZt38A&ab_channel=MITOpenCourseWare" target="_blank" rel="noopener noreferrer">MIT (video)</a>
     - C/C++:
-        - [ ] [Binary search tree - Implementation in C/C++ (video)](https://www.youtube.com/watch?v=COZK7NATh4k&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=28)
-        - [ ] [BST implementation - memory allocation in stack and heap (video)](https://www.youtube.com/watch?v=hWokyBoo0aI&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=29)
-        - [ ] [Find min and max element in a binary search tree (video)](https://www.youtube.com/watch?v=Ut90klNN264&index=30&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P)
-        - [ ] [Find the height of a binary tree (video)](https://www.youtube.com/watch?v=_pnqMz5nrRs&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=31)
-        - [ ] [Binary tree traversal - breadth-first and depth-first strategies (video)](https://www.youtube.com/watch?v=9RHO6jU--GU&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=32)
-        - [ ] [Binary tree: Level Order Traversal (video)](https://www.youtube.com/watch?v=86g8jAQug04&index=33&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P)
-        - [ ] [Binary tree traversal: Preorder, Inorder, Postorder (video)](https://www.youtube.com/watch?v=gm8DUJJhmY4&index=34&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P)
-        - [ ] [Check if a binary tree is a binary search tree or not (video)](https://www.youtube.com/watch?v=yEwSGhSsT0U&index=35&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P)
-        - [ ] [Delete a node from Binary Search Tree (video)](https://www.youtube.com/watch?v=gcULXE7ViZw&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=36)
-        - [ ] [Inorder Successor in a binary search tree (video)](https://www.youtube.com/watch?v=5cPbNCrdotA&index=37&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P)
+        - [ ] <a href="https://www.youtube.com/watch?v=COZK7NATh4k&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=28" target="_blank" rel="noopener noreferrer">Binary search tree - Implementation in C/C++ (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=hWokyBoo0aI&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=29" target="_blank" rel="noopener noreferrer">BST implementation - memory allocation in stack and heap (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=Ut90klNN264&index=30&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P" target="_blank" rel="noopener noreferrer">Find min and max element in a binary search tree (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=_pnqMz5nrRs&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=31" target="_blank" rel="noopener noreferrer">Find the height of a binary tree (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=9RHO6jU--GU&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=32" target="_blank" rel="noopener noreferrer">Binary tree traversal - breadth-first and depth-first strategies (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=86g8jAQug04&index=33&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P" target="_blank" rel="noopener noreferrer">Binary tree: Level Order Traversal (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=gm8DUJJhmY4&index=34&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P" target="_blank" rel="noopener noreferrer">Binary tree traversal: Preorder, Inorder, Postorder (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=yEwSGhSsT0U&index=35&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P" target="_blank" rel="noopener noreferrer">Check if a binary tree is a binary search tree or not (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=gcULXE7ViZw&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P&index=36" target="_blank" rel="noopener noreferrer">Delete a node from Binary Search Tree (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=5cPbNCrdotA&index=37&list=PL2_aWCzGMAwI3W_JlcBbtYTwiQSsOTa6P" target="_blank" rel="noopener noreferrer">Inorder Successor in a binary search tree (video)</a>
     - [ ] Implement:
-        - [ ] [insert    // insert value into tree](https://leetcode.com/problems/insert-into-a-binary-search-tree/submissions/987660183/)
+        - [ ] <a href="https://leetcode.com/problems/insert-into-a-binary-search-tree/submissions/987660183/" target="_blank" rel="noopener noreferrer">insert    // insert value into tree</a>
         - [ ] get_node_count // get count of values stored
         - [ ] print_values // prints the values in the tree, from min to max
         - [ ] delete_tree
         - [ ] is_in_tree // returns true if a given value exists in the tree
-        - [ ] [get_height // returns the height in nodes (single node's height is 1)](https://www.geeksforgeeks.org/find-the-maximum-depth-or-height-of-a-tree/)
+        - [ ] <a href="https://www.geeksforgeeks.org/find-the-maximum-depth-or-height-of-a-tree/" target="_blank" rel="noopener noreferrer">get_height // returns the height in nodes (single node's height is 1)</a>
         - [ ] get_min   // returns the minimum value stored in the tree
         - [ ] get_max   // returns the maximum value stored in the tree
-        - [ ] [is_binary_search_tree](https://leetcode.com/problems/validate-binary-search-tree/)
+        - [ ] <a href="https://leetcode.com/problems/validate-binary-search-tree/" target="_blank" rel="noopener noreferrer">is_binary_search_tree</a>
         - [ ] delete_value
         - [ ] get_successor // returns the next-highest value in the tree after given value, -1 if none
 
 - ### Heap / Priority Queue / Binary Heap
     - visualized as a tree, but is usually linear in storage (array, linked list)
-    - [ ] [Heap](https://en.wikipedia.org/wiki/Heap_(data_structure))
-    - [ ] [Introduction (video)](https://www.coursera.org/lecture/data-structures/introduction-2OpTs)
-    - [ ] [Binary Trees (video)](https://www.coursera.org/learn/data-structures/lecture/GRV2q/binary-trees)
-    - [ ] [Tree Height Remark (video)](https://www.coursera.org/learn/data-structures/supplement/S5xxz/tree-height-remark)
-    - [ ] [Basic Operations (video)](https://www.coursera.org/learn/data-structures/lecture/0g1dl/basic-operations)
-    - [ ] [Complete Binary Trees (video)](https://www.coursera.org/learn/data-structures/lecture/gl5Ni/complete-binary-trees)
-    - [ ] [Pseudocode (video)](https://www.coursera.org/learn/data-structures/lecture/HxQo9/pseudocode)
-    - [ ] [Heap Sort - jumps to start (video)](https://youtu.be/odNJmw5TOEE?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=3291)
-    - [ ] [Heap Sort (video)](https://www.coursera.org/lecture/data-structures/heap-sort-hSzMO)
-    - [ ] [Building a heap (video)](https://www.coursera.org/lecture/data-structures/building-a-heap-dwrOS)
-    - [ ] [MIT 6.006 Introduction to Algorithms: Binary Heaps](https://www.youtube.com/watch?v=Xnpo1atN-Iw&list=PLUl4u3cNGP63EdVPNLG3ToM6LaEUuStEY&index=12)
-    - [ ] [CS 61B Lecture 24: Priority Queues (video)](https://archive.org/details/ucberkeley_webcast_yIUFT6AKBGE)
-    - [ ] [Linear Time BuildHeap (max-heap)](https://www.youtube.com/watch?v=MiyLo8adrWw)
-    - [ ] [[Review] Heap (playlist) in 13 minutes (video)](https://www.youtube.com/playlist?list=PL9xmBV_5YoZNsyqgPW-DNwUeT8F8uhWc6)
+    - [ ] <a href="https://en.wikipedia.org/wiki/Heap_(data_structure)" target="_blank" rel="noopener noreferrer">Heap</a>
+    - [ ] <a href="https://www.coursera.org/lecture/data-structures/introduction-2OpTs" target="_blank" rel="noopener noreferrer">Introduction (video)</a>
+    - [ ] <a href="https://www.coursera.org/learn/data-structures/lecture/GRV2q/binary-trees" target="_blank" rel="noopener noreferrer">Binary Trees (video)</a>
+    - [ ] <a href="https://www.coursera.org/learn/data-structures/supplement/S5xxz/tree-height-remark" target="_blank" rel="noopener noreferrer">Tree Height Remark (video)</a>
+    - [ ] <a href="https://www.coursera.org/learn/data-structures/lecture/0g1dl/basic-operations" target="_blank" rel="noopener noreferrer">Basic Operations (video)</a>
+    - [ ] <a href="https://www.coursera.org/learn/data-structures/lecture/gl5Ni/complete-binary-trees" target="_blank" rel="noopener noreferrer">Complete Binary Trees (video)</a>
+    - [ ] <a href="https://www.coursera.org/learn/data-structures/lecture/HxQo9/pseudocode" target="_blank" rel="noopener noreferrer">Pseudocode (video)</a>
+    - [ ] <a href="https://youtu.be/odNJmw5TOEE?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&amp;t=3291" target="_blank" rel="noopener noreferrer">Heap Sort - jumps to start (video)</a>
+    - [ ] <a href="https://www.coursera.org/lecture/data-structures/heap-sort-hSzMO" target="_blank" rel="noopener noreferrer">Heap Sort (video)</a>
+    - [ ] <a href="https://www.coursera.org/lecture/data-structures/building-a-heap-dwrOS" target="_blank" rel="noopener noreferrer">Building a heap (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=Xnpo1atN-Iw&amp;list=PLUl4u3cNGP63EdVPNLG3ToM6LaEUuStEY&amp;index=12" target="_blank" rel="noopener noreferrer">MIT 6.006 Introduction to Algorithms: Binary Heaps</a>
+    - [ ] <a href="https://archive.org/details/ucberkeley_webcast_yIUFT6AKBGE" target="_blank" rel="noopener noreferrer">CS 61B Lecture 24: Priority Queues (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=MiyLo8adrWw" target="_blank" rel="noopener noreferrer">Linear Time BuildHeap (max-heap)</a>
+    - [ ] <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZNsyqgPW-DNwUeT8F8uhWc6" target="_blank" rel="noopener noreferrer">[Review] Heap (playlist) in 13 minutes (video)</a>
     - [ ] Implement a max-heap:
         - [ ] insert
         - [ ] sift_up - needed for insert
@@ -844,64 +845,65 @@ if you can identify the runtime complexity of different algorithms. It's a super
 
 ## Sorting
 
-- [ ] Notes:
+- [] Notes:
     - Implement sorts & know best case/worst case, average complexity of each:
         - no bubble sort - it's terrible - O(n^2), except when n <= 16
-    - [ ] Stability in sorting algorithms ("Is Quicksort stable?")
-        - [Sorting Algorithm Stability](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
-        - [Stability In Sorting Algorithms](http://stackoverflow.com/questions/1517793/stability-in-sorting-algorithms)
-        - [Stability In Sorting Algorithms](http://www.geeksforgeeks.org/stability-in-sorting-algorithms/)
-        - [Sorting Algorithms - Stability](http://homepages.math.uic.edu/~leon/cs-mcs401-s08/handouts/stability.pdf)
-    - [ ] Which algorithms can be used on linked lists? Which on arrays? Which of both?
+    - [] Stability in sorting algorithms ("Is Quicksort stable?")
+        - <a href="https://en.wikipedia.org/wiki/Sorting_algorithm#Stability" target="_blank">Sorting Algorithm Stability</a>
+        - <a href="http://stackoverflow.com/questions/1517793/stability-in-sorting-algorithms" target="_blank">Stability In Sorting Algorithms</a>
+        - <a href="http://www.geeksforgeeks.org/stability-in-sorting-algorithms/" target="_blank">Stability In Sorting Algorithms</a>
+        - <a href="http://homepages.math.uic.edu/~leon/cs-mcs401-s08/handouts/stability.pdf" target="_blank">Sorting Algorithms - Stability</a>
+    - [] Which algorithms can be used on linked lists? Which on arrays? Which of both?
         - I wouldn't recommend sorting a linked list, but merge sort is doable.
-        - [Merge Sort For Linked List](http://www.geeksforgeeks.org/merge-sort-for-linked-list/)
+        - <a href="http://www.geeksforgeeks.org/merge-sort-for-linked-list/" target="_blank">Merge Sort For Linked List</a>
+
 
 - For heapsort, see the Heap data structure above. Heap sort is great, but not stable
 
-- [ ] [Sedgewick - Mergesort (5 videos)](https://www.coursera.org/learn/algorithms-part1/home/week/3)
-    - [ ] [1. Mergesort](https://www.coursera.org/lecture/algorithms-part1/mergesort-ARWDq)
-    - [ ] [2. Bottom-up Mergesort](https://www.coursera.org/learn/algorithms-part1/lecture/PWNEl/bottom-up-mergesort)
-    - [ ] [3. Sorting Complexity](https://www.coursera.org/lecture/algorithms-part1/sorting-complexity-xAltF)
-    - [ ] [4. Comparators](https://www.coursera.org/lecture/algorithms-part1/comparators-9FYhS)
-    - [ ] [5. Stability](https://www.coursera.org/learn/algorithms-part1/lecture/pvvLZ/stability)
+- [ ] <a href="https://www.coursera.org/learn/algorithms-part1/home/week/3" target="_blank" rel="noopener noreferrer">Sedgewick - Mergesort (5 videos)</a>
+    - [ ] <a href="https://www.coursera.org/lecture/algorithms-part1/mergesort-ARWDq" target="_blank" rel="noopener noreferrer">1. Mergesort</a>
+    - [ ] <a href="https://www.coursera.org/learn/algorithms-part1/lecture/PWNEl/bottom-up-mergesort" target="_blank" rel="noopener noreferrer">2. Bottom-up Mergesort</a>
+    - [ ] <a href="https://www.coursera.org/lecture/algorithms-part1/sorting-complexity-xAltF" target="_blank" rel="noopener noreferrer">3. Sorting Complexity</a>
+    - [ ] <a href="https://www.coursera.org/lecture/algorithms-part1/comparators-9FYhS" target="_blank" rel="noopener noreferrer">4. Comparators</a>
+    - [ ] <a href="https://www.coursera.org/learn/algorithms-part1/lecture/pvvLZ/stability" target="_blank" rel="noopener noreferrer">5. Stability</a>
 
-- [ ] [Sedgewick - Quicksort (4 videos)](https://www.coursera.org/learn/algorithms-part1/home/week/3)
-    - [ ] [1. Quicksort](https://www.coursera.org/lecture/algorithms-part1/quicksort-vjvnC)
-    - [ ] [2. Selection](https://www.coursera.org/lecture/algorithms-part1/selection-UQxFT)
-    - [ ] [3. Duplicate Keys](https://www.coursera.org/lecture/algorithms-part1/duplicate-keys-XvjPd)
-    - [ ] [4. System Sorts](https://www.coursera.org/lecture/algorithms-part1/system-sorts-QBNZ7)
+- [ ] <a href="https://www.coursera.org/learn/algorithms-part1/home/week/3" target="_blank" rel="noopener noreferrer">Sedgewick - Quicksort (4 videos)</a>
+    - [ ] <a href="https://www.coursera.org/lecture/algorithms-part1/quicksort-vjvnC" target="_blank" rel="noopener noreferrer">1. Quicksort</a>
+    - [ ] <a href="https://www.coursera.org/lecture/algorithms-part1/selection-UQxFT" target="_blank" rel="noopener noreferrer">2. Selection</a>
+    - [ ] <a href="https://www.coursera.org/lecture/algorithms-part1/duplicate-keys-XvjPd" target="_blank" rel="noopener noreferrer">3. Duplicate Keys</a>
+    - [ ] <a href="https://www.coursera.org/lecture/algorithms-part1/system-sorts-QBNZ7" target="_blank" rel="noopener noreferrer">4. System Sorts</a>
 
 - [ ] UC Berkeley:
-    - [ ] [CS 61B Lecture 29: Sorting I (video)](https://archive.org/details/ucberkeley_webcast_EiUvYS2DT6I)
-    - [ ] [CS 61B Lecture 30: Sorting II (video)](https://archive.org/details/ucberkeley_webcast_2hTY3t80Qsk)
-    - [ ] [CS 61B Lecture 32: Sorting III (video)](https://archive.org/details/ucberkeley_webcast_Y6LOLpxg6Dc)
-    - [ ] [CS 61B Lecture 33: Sorting V (video)](https://archive.org/details/ucberkeley_webcast_qNMQ4ly43p4)
-    - [ ] [CS 61B 2014-04-21: Radix Sort(video)](https://archive.org/details/ucberkeley_webcast_pvbBMd-3NoI)
+    - [ ] <a href="https://archive.org/details/ucberkeley_webcast_EiUvYS2DT6I" target="_blank" rel="noopener noreferrer">CS 61B Lecture 29: Sorting I (video)</a>
+    - [ ] <a href="https://archive.org/details/ucberkeley_webcast_2hTY3t80Qsk" target="_blank" rel="noopener noreferrer">CS 61B Lecture 30: Sorting II (video)</a>
+    - [ ] <a href="https://archive.org/details/ucberkeley_webcast_Y6LOLpxg6Dc" target="_blank" rel="noopener noreferrer">CS 61B Lecture 32: Sorting III (video)</a>
+    - [ ] <a href="https://archive.org/details/ucberkeley_webcast_qNMQ4ly43p4" target="_blank" rel="noopener noreferrer">CS 61B Lecture 33: Sorting V (video)</a>
+    - [ ] <a href="https://archive.org/details/ucberkeley_webcast_pvbBMd-3NoI" target="_blank" rel="noopener noreferrer">CS 61B 2014-04-21: Radix Sort(video)</a>
 
-- [ ] [Bubble Sort (video)](https://www.youtube.com/watch?v=P00xJgWzz2c&index=1&list=PL89B61F78B552C1AB)
-- [ ] [Analyzing Bubble Sort (video)](https://www.youtube.com/watch?v=ni_zk257Nqo&index=7&list=PL89B61F78B552C1AB)
-- [ ] [Insertion Sort, Merge Sort (video)](https://www.youtube.com/watch?v=Kg4bqzAqRBM&index=3&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb)
-- [ ] [Insertion Sort (video)](https://www.youtube.com/watch?v=c4BRHC7kTaQ&index=2&list=PL89B61F78B552C1AB)
-- [ ] [Merge Sort (video)](https://www.youtube.com/watch?v=GCae1WNvnZM&index=3&list=PL89B61F78B552C1AB)
-- [ ] [Quicksort (video)](https://www.youtube.com/watch?v=y_G9BkAm6B8&index=4&list=PL89B61F78B552C1AB)
-- [ ] [Selection Sort (video)](https://www.youtube.com/watch?v=6nDMgr0-Yyo&index=8&list=PL89B61F78B552C1AB)
+- [ ] <a href="https://www.youtube.com/watch?v=P00xJgWzz2c&index=1&list=PL89B61F78B552C1AB" target="_blank" rel="noopener noreferrer">Bubble Sort (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=ni_zk257Nqo&index=7&list=PL89B61F78B552C1AB" target="_blank" rel="noopener noreferrer">Analyzing Bubble Sort (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=Kg4bqzAqRBM&index=3&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb" target="_blank" rel="noopener noreferrer">Insertion Sort, Merge Sort (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=c4BRHC7kTaQ&index=2&list=PL89B61F78B552C1AB" target="_blank" rel="noopener noreferrer">Insertion Sort (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=GCae1WNvnZM&index=3&list=PL89B61F78B552C1AB" target="_blank" rel="noopener noreferrer">Merge Sort (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=y_G9BkAm6B8&index=4&list=PL89B61F78B552C1AB" target="_blank" rel="noopener noreferrer">Quicksort (video)</a>
+- [ ] <a href="https://www.youtube.com/watch?v=6nDMgr0-Yyo&index=8&list=PL89B61F78B552C1AB" target="_blank" rel="noopener noreferrer">Selection Sort (video)</a>
 
 - [ ] Merge sort code:
-    - [ ] [Using output array (C)](http://www.cs.yale.edu/homes/aspnes/classes/223/examples/sorting/mergesort.c)
-    - [ ] [Using output array (Python)](https://github.com/jwasham/practice-python/blob/master/merge_sort/merge_sort.py)
-    - [ ] [In-place (C++)](https://github.com/jwasham/practice-cpp/blob/master/merge_sort/merge_sort.cc)
+    - [ ] <a href="http://www.cs.yale.edu/homes/aspnes/classes/223/examples/sorting/mergesort.c" target="_blank" rel="noopener noreferrer">Using output array (C)</a>
+    - [ ] <a href="https://github.com/jwasham/practice-python/blob/master/merge_sort/merge_sort.py" target="_blank" rel="noopener noreferrer">Using output array (Python)</a>
+    - [ ] <a href="https://github.com/jwasham/practice-cpp/blob/master/merge_sort/merge_sort.cc" target="_blank" rel="noopener noreferrer">In-place (C++)</a>
 - [ ] Quick sort code:
-    - [ ] [Implementation (C)](http://www.cs.yale.edu/homes/aspnes/classes/223/examples/randomization/quick.c)
-    - [ ] [Implementation (C)](https://github.com/jwasham/practice-c/blob/master/quick_sort/quick_sort.c)
-    - [ ] [Implementation (Python)](https://github.com/jwasham/practice-python/blob/master/quick_sort/quick_sort.py)
+    - [ ] <a href="http://www.cs.yale.edu/homes/aspnes/classes/223/examples/randomization/quick.c" target="_blank" rel="noopener noreferrer">Implementation (C)</a>
+    - [ ] <a href="https://github.com/jwasham/practice-c/blob/master/quick_sort/quick_sort.c" target="_blank" rel="noopener noreferrer">Implementation (C)</a>
+    - [ ] <a href="https://github.com/jwasham/practice-python/blob/master/quick_sort/quick_sort.py" target="_blank" rel="noopener noreferrer">Implementation (Python)</a>
 
-- [ ] [[Review] Sorting (playlist) in 18 minutes](https://www.youtube.com/playlist?list=PL9xmBV_5YoZOZSbGAXAPIq1BeUf4j20pl)
-    - [ ] [Quick sort in 4 minutes (video)](https://youtu.be/Hoixgm4-P4M)
-    - [ ] [Heap sort in 4 minutes (video)](https://youtu.be/2DmK_H7IdTo)
-    - [ ] [Merge sort in 3 minutes (video)](https://youtu.be/4VqmGXwpLqc)
-    - [ ] [Bubble sort in 2 minutes (video)](https://youtu.be/xli_FI7CuzA)
-    - [ ] [Selection sort in 3 minutes (video)](https://youtu.be/g-PGLbMth_g)
-    - [ ] [Insertion sort in 2 minutes (video)](https://youtu.be/JU767SDMDvA)
+- [ ] <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZOZSbGAXAPIq1BeUf4j20pl" target="_blank" rel="noopener noreferrer">[Review] Sorting (playlist) in 18 minutes</a>
+    - [ ] <a href="https://youtu.be/Hoixgm4-P4M" target="_blank" rel="noopener noreferrer">Quick sort in 4 minutes (video)</a>
+    - [ ] <a href="https://youtu.be/2DmK_H7IdTo" target="_blank" rel="noopener noreferrer">Heap sort in 4 minutes (video)</a>
+    - [ ] <a href="https://youtu.be/4VqmGXwpLqc" target="_blank" rel="noopener noreferrer">Merge sort in 3 minutes (video)</a>
+    - [ ] <a href="https://youtu.be/xli_FI7CuzA" target="_blank" rel="noopener noreferrer">Bubble sort in 2 minutes (video)</a>
+    - [ ] <a href="https://youtu.be/g-PGLbMth_g" target="_blank" rel="noopener noreferrer">Selection sort in 3 minutes (video)</a>
+    - [ ] <a href="https://youtu.be/JU767SDMDvA" target="_blank" rel="noopener noreferrer">Insertion sort in 2 minutes (video)</a>
 
 - [ ] Implement:
     - [ ] Mergesort: O(n log n) average and worst case
@@ -910,20 +912,20 @@ if you can identify the runtime complexity of different algorithms. It's a super
     - For heapsort, see Heap data structure above
 
 - [ ] Not required, but I recommended them:
-    - [ ] [Sedgewick - Radix Sorts (6 videos)](https://www.coursera.org/learn/algorithms-part2/home/week/3)
-        - [ ] [1. Strings in Java](https://www.coursera.org/learn/algorithms-part2/lecture/vGHvb/strings-in-java)
-        - [ ] [2. Key Indexed Counting](https://www.coursera.org/lecture/algorithms-part2/key-indexed-counting-2pi1Z)
-        - [ ] [3. Least Significant Digit First String Radix Sort](https://www.coursera.org/learn/algorithms-part2/lecture/c1U7L/lsd-radix-sort)
-        - [ ] [4. Most Significant Digit First String Radix Sort](https://www.coursera.org/learn/algorithms-part2/lecture/gFxwG/msd-radix-sort)
-        - [ ] [5. 3 Way Radix Quicksort](https://www.coursera.org/lecture/algorithms-part2/3-way-radix-quicksort-crkd5)
-        - [ ] [6. Suffix Arrays](https://www.coursera.org/learn/algorithms-part2/lecture/TH18W/suffix-arrays)
-    - [ ] [Radix Sort](http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#radixSort)
-    - [ ] [Radix Sort (video)](https://www.youtube.com/watch?v=xhr26ia4k38)
-    - [ ] [Radix Sort, Counting Sort (linear time given constraints) (video)](https://www.youtube.com/watch?v=Nz1KZXbghj8&index=7&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb)
-    - [ ] [Randomization: Matrix Multiply, Quicksort, Freivalds' algorithm (video)](https://www.youtube.com/watch?v=cNB2lADK3_s&index=8&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp)
-    - [ ] [Sorting in Linear Time (video)](https://www.youtube.com/watch?v=pOKy3RZbSws&list=PLUl4u3cNGP61hsJNdULdudlRL493b-XZf&index=14)
+    - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/home/week/3" target="_blank">Sedgewick - Radix Sorts (6 videos)</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/vGHvb/strings-in-java" target="_blank">1. Strings in Java</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithms-part2/key-indexed-counting-2pi1Z" target="_blank">2. Key Indexed Counting</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/c1U7L/lsd-radix-sort" target="_blank">3. Least Significant Digit First String Radix Sort</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/gFxwG/msd-radix-sort" target="_blank">4. Most Significant Digit First String Radix Sort</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithms-part2/3-way-radix-quicksort-crkd5" target="_blank">5. 3 Way Radix Quicksort</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/TH18W/suffix-arrays" target="_blank">6. Suffix Arrays</a>
+    - [ ] <a href="http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#radixSort" target="_blank">Radix Sort</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=xhr26ia4k38" target="_blank">Radix Sort (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=Nz1KZXbghj8&index=7&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb" target="_blank">Radix Sort, Counting Sort (linear time given constraints) (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=cNB2lADK3_s&index=8&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp" target="_blank">Randomization: Matrix Multiply, Quicksort, Freivalds' algorithm (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=pOKy3RZbSws&list=PLUl4u3cNGP61hsJNdULdudlRL493b-XZf&index=14" target="_blank">Sorting in Linear Time (video)</a>
 
-As a summary, here is a visual representation of [15 sorting algorithms](https://www.youtube.com/watch?v=kPRA0W1kECg).
+As a summary, here is a visual representation of <a href="https://www.youtube.com/watch?v=kPRA0W1kECg" target="_blank">15 sorting algorithms</a>.
 If you need more detail on this subject, see the "Sorting" section in [Additional Detail on Some Subjects](#additional-detail-on-some-subjects)
 
 **[⬆ back to top](#table-of-contents)**
@@ -943,35 +945,34 @@ Graphs can be used to represent many problems in computer science, so this secti
     - When asked a question, look for a graph-based solution first, then move on if none
 
 - [ ] MIT(videos):
-    - [ ] [Breadth-First Search](https://www.youtube.com/watch?v=oFVYVzlvk9c&t=14s&ab_channel=MITOpenCourseWare)
-    - [ ] [Depth-First Search](https://www.youtube.com/watch?v=IBfWDYSffUU&t=32s&ab_channel=MITOpenCourseWare)
+    - [ ] <a href="https://www.youtube.com/watch?v=oFVYVzlvk9c&t=14s&ab_channel=MITOpenCourseWare" target="_blank" rel="noopener noreferrer">Breadth-First Search</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=IBfWDYSffUU&t=32s&ab_channel=MITOpenCourseWare" target="_blank" rel="noopener noreferrer">Depth-First Search</a>
 
 - [ ] Skiena Lectures - great intro:
-    - [ ] [CSE373 2020 - Lecture 10 - Graph Data Structures (video)](https://www.youtube.com/watch?v=Sjk0xqWWPCc&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=10)
-    - [ ] [CSE373 2020 - Lecture 11 - Graph Traversal (video)](https://www.youtube.com/watch?v=ZTwjXj81NVY&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=11)
-    - [ ] [CSE373 2020 - Lecture 12 - Depth First Search (video)](https://www.youtube.com/watch?v=KyordYB3BOs&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=12)
-    - [ ] [CSE373 2020 - Lecture 13 - Minimum Spanning Trees (video)](https://www.youtube.com/watch?v=oolm2VnJUKw&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=13)
-    - [ ] [CSE373 2020 - Lecture 14 - Minimum Spanning Trees (con't) (video)](https://www.youtube.com/watch?v=RktgPx0MarY&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=14)
-    - [ ] [CSE373 2020 - Lecture 15 - Graph Algorithms (con't 2) (video)](https://www.youtube.com/watch?v=MUe5DXRhyAo&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=15)
+    - [ ] <a href="https://www.youtube.com/watch?v=Sjk0xqWWPCc&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=10" target="_blank" rel="noopener noreferrer">CSE373 2020 - Lecture 10 - Graph Data Structures (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=ZTwjXj81NVY&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=11" target="_blank" rel="noopener noreferrer">CSE373 2020 - Lecture 11 - Graph Traversal (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=KyordYB3BOs&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=12" target="_blank" rel="noopener noreferrer">CSE373 2020 - Lecture 12 - Depth First Search (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=oolm2VnJUKw&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=13" target="_blank" rel="noopener noreferrer">CSE373 2020 - Lecture 13 - Minimum Spanning Trees (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=RktgPx0MarY&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=14" target="_blank" rel="noopener noreferrer">CSE373 2020 - Lecture 14 - Minimum Spanning Trees (con't) (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=MUe5DXRhyAo&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=15" target="_blank" rel="noopener noreferrer">CSE373 2020 - Lecture 15 - Graph Algorithms (con't 2) (video)</a>
 
 - [ ] Graphs (review and more):
-
-    - [ ] [6.006 Single-Source Shortest Paths Problem (video)](https://www.youtube.com/watch?v=Aa2sqUhIn-E&index=15&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb)
-    - [ ] [6.006 Dijkstra (video)](https://www.youtube.com/watch?v=NSHizBK9JD8&t=1731s&ab_channel=MITOpenCourseWare)
-    - [ ] [6.006 Bellman-Ford (video)](https://www.youtube.com/watch?v=f9cVS_URPc0&ab_channel=MITOpenCourseWare)
-    - [ ] [6.006 Speeding Up Dijkstra (video)](https://www.youtube.com/watch?v=CHvQ3q_gJ7E&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=18)
-    - [ ] [Aduni: Graph Algorithms I - Topological Sorting, Minimum Spanning Trees, Prim's Algorithm -  Lecture 6 (video)]( https://www.youtube.com/watch?v=i_AQT_XfvD8&index=6&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm)
-    - [ ] [Aduni: Graph Algorithms II - DFS, BFS, Kruskal's Algorithm, Union Find Data Structure - Lecture 7 (video)]( https://www.youtube.com/watch?v=ufj5_bppBsA&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=7)
-    - [ ] [Aduni: Graph Algorithms III: Shortest Path - Lecture 8 (video)](https://www.youtube.com/watch?v=DiedsPsMKXc&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=8)
-    - [ ] [Aduni: Graph Alg. IV: Intro to geometric algorithms - Lecture 9 (video)](https://www.youtube.com/watch?v=XIAQRlNkJAw&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=9)
-    - [ ] [CS 61B 2014: Weighted graphs (video)](https://archive.org/details/ucberkeley_webcast_zFbq8vOZ_0k)
-    - [ ] [Greedy Algorithms: Minimum Spanning Tree (video)](https://www.youtube.com/watch?v=tKwnms5iRBU&index=16&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp)
-    - [ ] [Strongly Connected Components Kosaraju's Algorithm Graph Algorithm (video)](https://www.youtube.com/watch?v=RpgcYiky7uw)
-    - [ ] [[Review] Shortest Path Algorithms (playlist) in 16 minutes (video)](https://www.youtube.com/playlist?list=PL9xmBV_5YoZO-Y-H3xIC9DGSfVYJng9Yw)
-    - [ ] [[Review] Minimum Spanning Trees (playlist) in 4 minutes (video)](https://www.youtube.com/playlist?list=PL9xmBV_5YoZObEi3Hf6lmyW-CBfs7nkOV)
+    - [ ] <a href="https://www.youtube.com/watch?v=Aa2sqUhIn-E&index=15&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb" target="_blank" rel="noopener noreferrer">6.006 Single-Source Shortest Paths Problem (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=NSHizBK9JD8&t=1731s&ab_channel=MITOpenCourseWare" target="_blank" rel="noopener noreferrer">6.006 Dijkstra (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=f9cVS_URPc0&ab_channel=MITOpenCourseWare" target="_blank" rel="noopener noreferrer">6.006 Bellman-Ford (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=CHvQ3q_gJ7E&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=18" target="_blank" rel="noopener noreferrer">6.006 Speeding Up Dijkstra (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=i_AQT_XfvD8&index=6&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm" target="_blank" rel="noopener noreferrer">Aduni: Graph Algorithms I - Topological Sorting, Minimum Spanning Trees, Prim's Algorithm -  Lecture 6 (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=ufj5_bppBsA&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=7" target="_blank" rel="noopener noreferrer">Aduni: Graph Algorithms II - DFS, BFS, Kruskal's Algorithm, Union Find Data Structure - Lecture 7 (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=DiedsPsMKXc&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=8" target="_blank" rel="noopener noreferrer">Aduni: Graph Algorithms III: Shortest Path - Lecture 8 (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=XIAQRlNkJAw&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=9" target="_blank" rel="noopener noreferrer">Aduni: Graph Alg. IV: Intro to geometric algorithms - Lecture 9 (video)</a>
+    - [ ] <a href="https://archive.org/details/ucberkeley_webcast_zFbq8vOZ_0k" target="_blank" rel="noopener noreferrer">CS 61B 2014: Weighted graphs (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=tKwnms5iRBU&index=16&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp" target="_blank" rel="noopener noreferrer">Greedy Algorithms: Minimum Spanning Tree (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=RpgcYiky7uw" target="_blank" rel="noopener noreferrer">Strongly Connected Components Kosaraju's Algorithm Graph Algorithm (video)</a>
+    - [ ] <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZO-Y-H3xIC9DGSfVYJng9Yw" target="_blank" rel="noopener noreferrer">[Review] Shortest Path Algorithms (playlist) in 16 minutes (video)</a>
+    - [ ] <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZObEi3Hf6lmyW-CBfs7nkOV" target="_blank" rel="noopener noreferrer">[Review] Minimum Spanning Trees (playlist) in 4 minutes (video)</a>
 
 - Full Coursera Course:
-    - [ ] [Algorithms on Graphs (video)](https://www.coursera.org/learn/algorithms-on-graphs/home/welcome)
+    - [ ] <a href="https://www.coursera.org/learn/algorithms-on-graphs/home/welcome" target="_blank" rel="noopener noreferrer">Algorithms on Graphs (video)</a>
 
 - I'll implement:
     - [ ] DFS with adjacency list (recursive)
@@ -995,47 +996,47 @@ Graphs can be used to represent many problems in computer science, so this secti
 
 - ### Recursion
     - [ ] Stanford lectures on recursion & backtracking:
-        - [ ] [Lecture 8 | Programming Abstractions (video)](https://www.youtube.com/watch?v=gl3emqCuueQ&list=PLFE6E58F856038C69&index=8)
-        - [ ] [Lecture 9 | Programming Abstractions (video)](https://www.youtube.com/watch?v=uFJhEPrbycQ&list=PLFE6E58F856038C69&index=9)
-        - [ ] [Lecture 10 | Programming Abstractions (video)](https://www.youtube.com/watch?v=NdF1QDTRkck&index=10&list=PLFE6E58F856038C69)
-        - [ ] [Lecture 11 | Programming Abstractions (video)](https://www.youtube.com/watch?v=p-gpaIGRCQI&list=PLFE6E58F856038C69&index=11)
+        - [ ] <a href="https://www.youtube.com/watch?v=gl3emqCuueQ&list=PLFE6E58F856038C69&index=8" target="_blank">Lecture 8 | Programming Abstractions (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=uFJhEPrbycQ&list=PLFE6E58F856038C69&index=9" target="_blank">Lecture 9 | Programming Abstractions (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=NdF1QDTRkck&index=10&list=PLFE6E58F856038C69" target="_blank">Lecture 10 | Programming Abstractions (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=p-gpaIGRCQI&list=PLFE6E58F856038C69&index=11" target="_blank">Lecture 11 | Programming Abstractions (video)</a>
     - When it is appropriate to use it?
     - How is tail recursion better than not?
-        - [ ] [What Is Tail Recursion Why Is It So Bad?](https://www.quora.com/What-is-tail-recursion-Why-is-it-so-bad)
-        - [ ] [Tail Recursion (video)](https://www.coursera.org/lecture/programming-languages/tail-recursion-YZic1)
-    - [ ] [5 Simple Steps for Solving Any Recursive Problem(video)](https://youtu.be/ngCos392W4w)
+        - [ ] <a href="https://www.quora.com/What-is-tail-recursion-Why-is-it-so-bad" target="_blank">What Is Tail Recursion Why Is It So Bad?</a>
+        - [ ] <a href="https://www.coursera.org/lecture/programming-languages/tail-recursion-YZic1" target="_blank">Tail Recursion (video)</a>
+    - [ ] <a href="https://youtu.be/ngCos392W4w" target="_blank">5 Simple Steps for Solving Any Recursive Problem(video)</a>
 
-	Backtracking Blueprint: [Java](https://leetcode.com/problems/combination-sum/discuss/16502/A-general-approach-to-backtracking-questions-in-Java-(Subsets-Permutations-Combination-Sum-Palindrome-Partitioning))
-	[Python](https://leetcode.com/problems/combination-sum/discuss/429538/General-Backtracking-questions-solutions-in-Python-for-reference-%3A)
+	Backtracking Blueprint: <a href="https://leetcode.com/problems/combination-sum/discuss/16502/A-general-approach-to-backtracking-questions-in-Java-(Subsets-Permutations-Combination-Sum-Palindrome-Partitioning)" target="_blank">Java</a>
+	<a href="https://leetcode.com/problems/combination-sum/discuss/429538/General-Backtracking-questions-solutions-in-Python-for-reference-%3A" target="_blank">Python</a>
 - ### Dynamic Programming
     - You probably won't see any dynamic programming problems in your interview, but it's worth being able to recognize a
     problem as being a candidate for dynamic programming.
     - This subject can be pretty difficult, as each DP soluble problem must be defined as a recursion relation, and coming up with it can be tricky.
     - I suggest looking at many examples of DP problems until you have a solid understanding of the pattern involved.
     - [ ] Videos:
-        - [ ] [Skiena: CSE373 2020 - Lecture 19 - Introduction to Dynamic Programming (video)](https://www.youtube.com/watch?v=wAA0AMfcJHQ&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=18)
-        - [ ] [Skiena: CSE373 2020 - Lecture 20 - Edit Distance (video)](https://www.youtube.com/watch?v=T3A4jlHlhtA&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=19)
-        - [ ] [Skiena: CSE373 2020 - Lecture 20 - Edit Distance (continued) (video)](https://www.youtube.com/watch?v=iPnPVcZmRbE&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=20)
-        - [ ] [Skiena: CSE373 2020 - Lecture 21 - Dynamic Programming (video)](https://www.youtube.com/watch?v=2xPE4Wq8coQ&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=21)
-        - [ ] [Skiena: CSE373 2020 - Lecture 22 - Dynamic Programming and Review (video)](https://www.youtube.com/watch?v=Yh3RzqQGsyI&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=22)
-        - [ ] [Simonson: Dynamic Programming 0 (starts at 59:18) (video)](https://youtu.be/J5aJEcOr6Eo?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=3558)
-        - [ ] [Simonson: Dynamic Programming I - Lecture 11 (video)](https://www.youtube.com/watch?v=0EzHjQ_SOeU&index=11&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm)
-        - [ ] [Simonson: Dynamic programming II - Lecture 12 (video)](https://www.youtube.com/watch?v=v1qiRwuJU7g&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=12)
+        - [ ] <a href="https://www.youtube.com/watch?v=wAA0AMfcJHQ&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=18" target="_blank">Skiena: CSE373 2020 - Lecture 19 - Introduction to Dynamic Programming (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=T3A4jlHlhtA&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=19" target="_blank">Skiena: CSE373 2020 - Lecture 20 - Edit Distance (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=iPnPVcZmRbE&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=20" target="_blank">Skiena: CSE373 2020 - Lecture 20 - Edit Distance (continued) (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=2xPE4Wq8coQ&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=21" target="_blank">Skiena: CSE373 2020 - Lecture 21 - Dynamic Programming (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=Yh3RzqQGsyI&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=22" target="_blank">Skiena: CSE373 2020 - Lecture 22 - Dynamic Programming and Review (video)</a>
+        - [ ] <a href="https://youtu.be/J5aJEcOr6Eo?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=3558" target="_blank">Simonson: Dynamic Programming 0 (starts at 59:18) (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=0EzHjQ_SOeU&index=11&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm" target="_blank">Simonson: Dynamic Programming I - Lecture 11 (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=v1qiRwuJU7g&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=12" target="_blank">Simonson: Dynamic programming II - Lecture 12 (video)</a>
         - [ ] List of individual DP problems (each is short):
-            [Dynamic Programming (video)](https://www.youtube.com/playlist?list=PLrmLmBdmIlpsHaNTPP_jHHDx_os9ItYXr)
+            <a href="https://www.youtube.com/playlist?list=PLrmLmBdmIlpsHaNTPP_jHHDx_os9ItYXr" target="_blank">Dynamic Programming (video)</a>
     - [ ] Yale Lecture notes:
-        - [ ] [Dynamic Programming](http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#dynamicProgramming)
+        - [ ] <a href="http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#dynamicProgramming" target="_blank">Dynamic Programming</a>
     - [ ] Coursera:
-        - [ ] [The RNA secondary structure problem (video)](https://www.coursera.org/learn/algorithmic-thinking-2/lecture/80RrW/the-rna-secondary-structure-problem)
-        - [ ] [A dynamic programming algorithm (video)](https://www.coursera.org/lecture/algorithmic-thinking-2/a-dynamic-programming-algorithm-PSonq)
-        - [ ] [Illustrating the DP algorithm (video)](https://www.coursera.org/lecture/algorithmic-thinking-2/illustrating-the-dp-algorithm-oUEK2)
-        - [ ] [Running time of the DP algorithm (video)](https://www.coursera.org/learn/algorithmic-thinking-2/lecture/nfK2r/running-time-of-the-dp-algorithm)
-        - [ ] [DP vs. recursive implementation (video)](https://www.coursera.org/learn/algorithmic-thinking-2/lecture/M999a/dp-vs-recursive-implementation)
-        - [ ] [Global pairwise sequence alignment (video)](https://www.coursera.org/lecture/algorithmic-thinking-2/global-pairwise-sequence-alignment-UZ7o6)
-        - [ ] [Local pairwise sequence alignment (video)](https://www.coursera.org/learn/algorithmic-thinking-2/lecture/WnNau/local-pairwise-sequence-alignment)
+        - [ ] <a href="https://www.coursera.org/learn/algorithmic-thinking-2/lecture/80RrW/the-rna-secondary-structure-problem" target="_blank">The RNA secondary structure problem (video)</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithmic-thinking-2/a-dynamic-programming-algorithm-PSonq" target="_blank">A dynamic programming algorithm (video)</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithmic-thinking-2/illustrating-the-dp-algorithm-oUEK2" target="_blank">Illustrating the DP algorithm (video)</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithmic-thinking-2/running-time-of-the-dp-algorithm" target="_blank">Running time of the DP algorithm (video)</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithmic-thinking-2/lecture/M999a/dp-vs-recursive-implementation" target="_blank">DP vs. recursive implementation (video)</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithmic-thinking-2/global-pairwise-sequence-alignment-UZ7o6" target="_blank">Global pairwise sequence alignment (video)</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithmic-thinking-2/local-pairwise-sequence-alignment" target="_blank">Local pairwise sequence alignment (video)</a>
 
 - ### Design patterns
-    - [ ] [Quick UML review (video)](https://www.youtube.com/watch?v=3cmzqZzwNDM&list=PLGLfVvz_LVvQ5G-LdJ8RLqe-ndo7QITYc&index=3)
+    - [ ] <a href="https://www.youtube.com/watch?v=3cmzqZzwNDM&list=PLGLfVvz_LVvQ5G-LdJ8RLqe-ndo7QITYc&index=3" target="_blank">Quick UML review (video)</a>
     - [ ] Learn these patterns:
         - [ ] strategy
         - [ ] singleton
@@ -1054,64 +1055,64 @@ Graphs can be used to represent many problems in computer science, so this secti
         - [ ] iterator
         - [ ] composite
         - [ ] flyweight
-    - [ ] [Series of videos (27 videos)](https://www.youtube.com/playlist?list=PLF206E906175C7E07)
-    - [ ] [Book: Head First Design Patterns](https://www.amazon.com/Head-First-Design-Patterns-Freeman/dp/0596007124)
+    - [ ] <a href="https://www.youtube.com/playlist?list=PLF206E906175C7E07" target="_blank">Series of videos (27 videos)</a>
+    - [ ] <a href="https://www.amazon.com/Head-First-Design-Patterns-Freeman/dp/0596007124" target="_blank">Book: Head First Design Patterns</a>
         - I know the canonical book is "Design Patterns: Elements of Reusable Object-Oriented Software", but Head First is great for beginners to OO.
-    - [Handy reference: 101 Design Patterns & Tips for Developers](https://sourcemaking.com/design-patterns-and-tips)
+    - <a href="https://sourcemaking.com/design-patterns-and-tips" target="_blank">Handy reference: 101 Design Patterns & Tips for Developers</a>
 
 - ### Combinatorics (n choose k) & Probability
-    - [ ] [Math Skills: How to find Factorial, Permutation, and Combination (Choose) (video)](https://www.youtube.com/watch?v=8RRo6Ti9d0U)
-    - [ ] [Make School: Probability (video)](https://www.youtube.com/watch?v=sZkAAk9Wwa4)
-    - [ ] [Make School: More Probability and Markov Chains (video)](https://www.youtube.com/watch?v=dNaJg-mLobQ)
+    - [ ] <a href="https://www.youtube.com/watch?v=8RRo6Ti9d0U" target="_blank">Math Skills: How to find Factorial, Permutation, and Combination (Choose) (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=sZkAAk9Wwa4" target="_blank">Make School: Probability (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=dNaJg-mLobQ" target="_blank">Make School: More Probability and Markov Chains (video)</a>
     - [ ] Khan Academy:
         - Course layout:
-            - [ ] [Basic Theoretical Probability](https://www.khanacademy.org/math/probability/probability-and-combinatorics-topic)
+            - [ ] <a href="https://www.khanacademy.org/math/probability/probability-and-combinatorics-topic" target="_blank">Basic Theoretical Probability</a>
         - Just the videos - 41 (each are simple and each are short):
-            - [ ] [Probability Explained (video)](https://www.youtube.com/watch?v=uzkc-qNVoOk&list=PLC58778F28211FA19)
+            - [ ] <a href="https://www.youtube.com/watch?v=uzkc-qNVoOk&list=PLC58778F28211FA19" target="_blank">Probability Explained (video)</a>
 
 - ### NP, NP-Complete and Approximation Algorithms
     - Know about the most famous classes of NP-complete problems, such as the traveling salesman and the knapsack problem,
         and be able to recognize them when an interviewer asks you them in disguise.
     - Know what NP-complete means.
-    - [ ] [Computational Complexity (video)](https://www.youtube.com/watch?v=moPtwq_cVH8&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=23)
+    - [ ] <a href="https://www.youtube.com/watch?v=moPtwq_cVH8&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=23" target="_blank">Computational Complexity (video)</a>
     - [ ] Simonson:
-        - [ ] [Greedy Algs. II & Intro to NP-Completeness (video)](https://youtu.be/qcGnJ47Smlo?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=2939)
-        - [ ] [NP Completeness II & Reductions (video)](https://www.youtube.com/watch?v=e0tGC6ZQdQE&index=16&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm)
-        - [ ] [NP Completeness III (Video)](https://www.youtube.com/watch?v=fCX1BGT3wjE&index=17&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm)
-        - [ ] [NP Completeness IV (video)](https://www.youtube.com/watch?v=NKLDp3Rch3M&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=18)
+        - [ ] <a href="https://youtu.be/qcGnJ47Smlo?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=2939" target="_blank">Greedy Algs. II & Intro to NP-Completeness (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=e0tGC6ZQdQE&index=16&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm" target="_blank">NP Completeness II & Reductions (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=fCX1BGT3wjE&index=17&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm" target="_blank">NP Completeness III (Video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=NKLDp3Rch3M&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=18" target="_blank">NP Completeness IV (video)</a>
     - [ ] Skiena:
-        - [ ] [CSE373 2020 - Lecture 23 - NP-Completeness (video)](https://www.youtube.com/watch?v=ItHp5laE1VE&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=23)
-        - [ ] [CSE373 2020 - Lecture 24 - Satisfiability (video)](https://www.youtube.com/watch?v=inaFJeCzGxU&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=24)
-        - [ ] [CSE373 2020 - Lecture 25 - More NP-Completeness (video)](https://www.youtube.com/watch?v=B-bhKxjZLlc&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=25)
-        - [ ] [CSE373 2020 - Lecture 26 - NP-Completeness Challenge (video)](https://www.youtube.com/watch?v=_EzetTkG_Cc&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=26)
-    - [ ] [Complexity: P, NP, NP-completeness, Reductions (video)](https://www.youtube.com/watch?v=eHZifpgyH_4&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=22)
-    - [ ] [Complexity: Approximation Algorithms (video)](https://www.youtube.com/watch?v=MEz1J9wY2iM&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=24)
-    - [ ] [Complexity: Fixed-Parameter Algorithms (video)](https://www.youtube.com/watch?v=4q-jmGrmxKs&index=25&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp)
+        - [ ] <a href="https://www.youtube.com/watch?v=ItHp5laE1VE&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=23" target="_blank">CSE373 2020 - Lecture 23 - NP-Completeness (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=inaFJeCzGxU&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=24" target="_blank">CSE373 2020 - Lecture 24 - Satisfiability (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=B-bhKxjZLlc&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=25" target="_blank">CSE373 2020 - Lecture 25 - More NP-Completeness (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=_EzetTkG_Cc&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=26" target="_blank">CSE373 2020 - Lecture 26 - NP-Completeness Challenge (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=eHZifpgyH_4&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=22" target="_blank">Complexity: P, NP, NP-completeness, Reductions (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=MEz1J9wY2iM&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=24" target="_blank">Complexity: Approximation Algorithms (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=4q-jmGrmxKs&index=25&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp" target="_blank">Complexity: Fixed-Parameter Algorithms (video)</a>
     - Peter Norvig discusses near-optimal solutions to the traveling salesman problem:
-        - [Jupyter Notebook](http://nbviewer.jupyter.org/url/norvig.com/ipython/TSP.ipynb)
+        - <a href="http://nbviewer.jupyter.org/url/norvig.com/ipython/TSP.ipynb" target="_blank">Jupyter Notebook</a>
     - Pages 1048 - 1140 in CLRS if you have it.
 
 - ### How computers process a program
 
-    - [ ] [How CPU executes a program (video)](https://www.youtube.com/watch?v=XM4lGflQFvA)
-    - [ ] [How computers calculate - ALU (video)](https://youtu.be/1I5ZMmrOfnA)
-    - [ ] [Registers and RAM (video)](https://youtu.be/fpnE6UAfbtU)
-    - [ ] [The Central Processing Unit (CPU) (video)](https://youtu.be/FZGugFqdr60)
-    - [ ] [Instructions and Programs (video)](https://youtu.be/zltgXvg6r3k)
+    - [ ] <a href="https://www.youtube.com/watch?v=XM4lGflQFvA" target="_blank">How CPU executes a program (video)</a>
+    - [ ] <a href="https://youtu.be/1I5ZMmrOfnA" target="_blank">How computers calculate - ALU (video)</a>
+    - [ ] <a href="https://youtu.be/fpnE6UAfbtU" target="_blank">Registers and RAM (video)</a>
+    - [ ] <a href="https://youtu.be/FZGugFqdr60" target="_blank">The Central Processing Unit (CPU) (video)</a>
+    - [ ] <a href="https://youtu.be/zltgXvg6r3k" target="_blank">Instructions and Programs (video)</a>
 - ### Caches
     - [ ] LRU cache:
-        - [ ] [The Magic of LRU Cache (100 Days of Google Dev) (video)](https://www.youtube.com/watch?v=R5ON3iwx78M)
-        - [ ] [Implementing LRU (video)](https://www.youtube.com/watch?v=bq6N7Ym81iI)
-        - [ ] [LeetCode - 146 LRU Cache (C++) (video)](https://www.youtube.com/watch?v=8-FZRAjR7qU)
+        - [ ] <a href="https://www.youtube.com/watch?v=R5ON3iwx78M" target="_blank">The Magic of LRU Cache (100 Days of Google Dev) (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=bq6N7Ym81iI" target="_blank">Implementing LRU (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=8-FZRAjR7qU" target="_blank">LeetCode - 146 LRU Cache (C++) (video)</a>
     - [ ] CPU cache:
-        - [ ] [MIT 6.004 L15: The Memory Hierarchy (video)](https://www.youtube.com/watch?v=vjYF_fAZI5E&list=PLrRW1w6CGAcXbMtDFj205vALOGmiRc82-&index=24)
-        - [ ] [MIT 6.004 L16: Cache Issues (video)](https://www.youtube.com/watch?v=ajgC3-pyGlk&index=25&list=PLrRW1w6CGAcXbMtDFj205vALOGmiRc82-)
+        - [ ] <a href="https://www.youtube.com/watch?v=vjYF_fAZI5E&list=PLrRW1w6CGAcXbMtDFj205vALOGmiRc82-&index=24" target="_blank">MIT 6.004 L15: The Memory Hierarchy (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=ajgC3-pyGlk&index=25&list=PLrRW1w6CGAcXbMtDFj205vALOGmiRc82-" target="_blank">MIT 6.004 L16: Cache Issues (video)</a>
 
 - ### Processes and Threads
     - [ ] Computer Science 162 - Operating Systems (25 videos):
         - for processes and threads see videos 1-11
-        - [Operating Systems and System Programming (video)](https://archive.org/details/ucberkeley-webcast-PL-XXv-cvA_iBDyz-ba4yDskqMDY6A1w_c)
-    - [What Is The Difference Between A Process And A Thread?](https://www.quora.com/What-is-the-difference-between-a-process-and-a-thread)
+        - <a href="https://archive.org/details/ucberkeley-webcast-PL-XXv-cvA_iBDyz-ba4yDskqMDY6A1w_c" target="_blank">Operating Systems and System Programming (video)</a>
+    - <a href="https://www.quora.com/What-is-the-difference-between-a-process-and-a-thread" target="_blank">What Is The Difference Between A Process And A Thread?</a>
     - Covers:
         - Processes, Threads, Concurrency issues
             - Difference between processes and threads
@@ -1126,23 +1127,23 @@ Graphs can be used to represent many problems in computer science, so this secti
             - Livelock
         - CPU activity, interrupts, context switching
         - Modern concurrency constructs with multicore processors
-        - [Paging, segmentation, and virtual memory (video)](https://youtu.be/O4nwUqQodAg)
-        - [Interrupts (video)](https://youtu.be/iKlAWIKEyuw)
+        - <a href="https://youtu.be/O4nwUqQodAg" target="_blank">Paging, segmentation, and virtual memory (video)</a>
+        - <a href="https://youtu.be/iKlAWIKEyuw" target="_blank">Interrupts (video)</a>
         - Process resource needs (memory: code, static storage, stack, heap, and also file descriptors, i/o)
         - Thread resource needs (shares above (minus stack) with other threads in the same process but each has its own PC, stack counter, registers, and stack)
         - Forking is really copy on write (read-only) until the new process writes to memory, then it does a full copy.
         - Context switching
-            - [How context switching is initiated by the operating system and underlying hardware?](https://www.javatpoint.com/what-is-the-context-switching-in-the-operating-system)
-    - [ ] [threads in C++ (series - 10 videos)](https://www.youtube.com/playlist?list=PL5jc9xFGsL8E12so1wlMS0r0hTQoJL74M)
-    - [ ] [CS 377 Spring '14: Operating Systems from University of Massachusetts](https://www.youtube.com/playlist?list=PLacuG5pysFbDQU8kKxbUh4K5c1iL5_k7k)
+            - <a href="https://www.javatpoint.com/what-is-the-context-switching-in-the-operating-system" target="_blank">How context switching is initiated by the operating system and underlying hardware?</a>
+    - [ ] <a href="https://www.youtube.com/playlist?list=PL5jc9xFGsL8E12so1wlMS0r0hTQoJL74M" target="_blank">threads in C++ (series - 10 videos)</a>
+    - [ ] <a href="https://www.youtube.com/playlist?list=PLacuG5pysFbDQU8kKxbUh4K5c1iL5_k7k" target="_blank">CS 377 Spring '14: Operating Systems from University of Massachusetts</a>
     - [ ] concurrency in Python (videos):
-        - [ ] [Short series on threads](https://www.youtube.com/playlist?list=PL1H1sBF1VAKVMONJWJkmUh6_p8g4F2oy1)
-        - [ ] [Python Threads](https://www.youtube.com/watch?v=Bs7vPNbB9JM)
-        - [ ] [Understanding the Python GIL (2010)](https://www.youtube.com/watch?v=Obt-vMVdM8s)
-            - [reference](http://www.dabeaz.com/GIL)
-        - [ ] [David Beazley - Python Concurrency From the Ground Up LIVE! - PyCon 2015](https://www.youtube.com/watch?v=MCs5OvhV9S4)
-        - [ ] [Keynote David Beazley - Topics of Interest (Python Asyncio)](https://www.youtube.com/watch?v=ZzfHjytDceU)
-        - [ ] [Mutex in Python](https://www.youtube.com/watch?v=0zaPs8OtyKY)
+        - [ ] <a href="https://www.youtube.com/playlist?list=PL1H1sBF1VAKVMONJWJkmUh6_p8g4F2oy1" target="_blank">Short series on threads</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=Bs7vPNbB9JM" target="_blank">Python Threads</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=Obt-vMVdM8s" target="_blank">Understanding the Python GIL (2010)</a>
+            - <a href="http://www.dabeaz.com/GIL" target="_blank">reference</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=MCs5OvhV9S4" target="_blank">David Beazley - Python Concurrency From the Ground Up LIVE! - PyCon 2015</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=ZzfHjytDceU" target="_blank">Keynote David Beazley - Topics of Interest (Python Asyncio)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=0zaPs8OtyKY" target="_blank">Mutex in Python</a>
 
 - ### Testing
     - To cover:
@@ -1150,75 +1151,75 @@ Graphs can be used to represent many problems in computer science, so this secti
         - what are mock objects
         - what is integration testing
         - what is dependency injection
-    - [ ] [Agile Software Testing with James Bach (video)](https://www.youtube.com/watch?v=SAhJf36_u5U)
-    - [ ] [Open Lecture by James Bach on Software Testing (video)](https://www.youtube.com/watch?v=ILkT_HV9DVU)
-    - [ ] [Steve Freeman - Test-Driven Development (that’s not what we meant) (video)](https://vimeo.com/83960706)
-        - [slides](http://gotocon.com/dl/goto-berlin-2013/slides/SteveFreeman_TestDrivenDevelopmentThatsNotWhatWeMeant.pdf)
+    - [ ] <a href="https://www.youtube.com/watch?v=SAhJf36_u5U" target="_blank">Agile Software Testing with James Bach (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=ILkT_HV9DVU" target="_blank">Open Lecture by James Bach on Software Testing (video)</a>
+    - [ ] <a href="https://vimeo.com/83960706" target="_blank">Steve Freeman - Test-Driven Development (that’s not what we meant) (video)</a>
+        - <a href="http://gotocon.com/dl/goto-berlin-2013/slides/SteveFreeman_TestDrivenDevelopmentThatsNotWhatWeMeant.pdf" target="_blank">slides</a>
     - [ ] Dependency injection:
-        - [ ] [video](https://www.youtube.com/watch?v=IKD2-MAkXyQ)
-        - [ ] [Tao Of Testing](http://jasonpolites.github.io/tao-of-testing/ch3-1.1.html)
-    - [ ] [How to write tests](http://jasonpolites.github.io/tao-of-testing/ch4-1.1.html)
+        - [ ] <a href="https://www.youtube.com/watch?v=IKD2-MAkXyQ" target="_blank">video</a>
+        - [ ] <a href="http://jasonpolites.github.io/tao-of-testing/ch3-1.1.html" target="_blank">Tao Of Testing</a>
+    - [ ] <a href="http://jasonpolites.github.io/tao-of-testing/ch4-1.1.html" target="_blank">How to write tests</a>
 
 - ### String searching & manipulations
-    - [ ] [Sedgewick - Suffix Arrays (video)](https://www.coursera.org/learn/algorithms-part2/lecture/TH18W/suffix-arrays)
-    - [ ] [Sedgewick - Substring Search (videos)](https://www.coursera.org/learn/algorithms-part2/home/week/4)
-        - [ ] [1. Introduction to Substring Search](https://www.coursera.org/lecture/algorithms-part2/introduction-to-substring-search-n3ZpG)
-        - [ ] [2. Brute-Force Substring Search](https://www.coursera.org/learn/algorithms-part2/lecture/2Kn5i/brute-force-substring-search)
-        - [ ] [3. Knuth-Morris Pratt](https://www.coursera.org/learn/algorithms-part2/lecture/TAtDr/knuth-morris-pratt)
-        - [ ] [4. Boyer-Moore](https://www.coursera.org/learn/algorithms-part2/lecture/CYxOT/boyer-moore)
-        - [ ] [5. Rabin-Karp](https://www.coursera.org/lecture/algorithms-part2/rabin-karp-3KiqT)
-    - [ ] [Search pattern in a text (video)](https://www.coursera.org/learn/data-structures/lecture/tAfHI/search-pattern-in-text)
+    - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/TH18W/suffix-arrays" target="_blank">Sedgewick - Suffix Arrays (video)</a>
+    - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/home/week/4" target="_blank">Sedgewick - Substring Search (videos)</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithms-part2/introduction-to-substring-search-n3ZpG" target="_blank">1. Introduction to Substring Search</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/2Kn5i/brute-force-substring-search" target="_blank">2. Brute-Force Substring Search</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/TAtDr/knuth-morris-pratt" target="_blank">3. Knuth-Morris Pratt</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/CYxOT/boyer-moore" target="_blank">4. Boyer-Moore</a>
+        - [ ] <a href="https://www.coursera.org/lecture/algorithms-part2/rabin-karp-3KiqT" target="_blank">5. Rabin-Karp</a>
+    - [ ] <a href="https://www.coursera.org/learn/data-structures/lecture/tAfHI/search-pattern-in-text" target="_blank">Search pattern in a text (video)</a>
 
-    If you need more detail on this subject, see the "String Matching" section in [Additional Detail on Some Subjects](#additional-detail-on-some-subjects).
+    If you need more detail on this subject, see the "String Matching" section in <a href="#additional-detail-on-some-subjects" target="_blank">Additional Detail on Some Subjects</a>.
 
 - ### Tries
     - Note there are different kinds of tries. Some have prefixes, some don't, and some use strings instead of bits
         to track the path
     - I read through the code, but will not implement
-    - [ ] [Sedgewick - Tries (3 videos)](https://www.coursera.org/learn/algorithms-part2/home/week/4)
-        - [ ] [1. R Way Tries](https://www.coursera.org/learn/algorithms-part2/lecture/CPVdr/r-way-tries)
-        - [ ] [2. Ternary Search Tries](https://www.coursera.org/learn/algorithms-part2/lecture/yQM8K/ternary-search-tries)
-        - [ ] [3. Character Based Operations](https://www.coursera.org/learn/algorithms-part2/lecture/jwNmV/character-based-operations)
-    - [ ] [Notes on Data Structures and Programming Techniques](http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#Tries)
+    - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/home/week/4" target="_blank">Sedgewick - Tries (3 videos)</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/CPVdr/r-way-tries" target="_blank">1. R Way Tries</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/yQM8K/ternary-search-tries" target="_blank">2. Ternary Search Tries</a>
+        - [ ] <a href="https://www.coursera.org/learn/algorithms-part2/lecture/jwNmV/character-based-operations" target="_blank">3. Character Based Operations</a>
+    - [ ] <a href="http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#Tries" target="_blank">Notes on Data Structures and Programming Techniques</a>
     - [ ] Short course videos:
-        - [ ] [Introduction To Tries (video)](https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/08Xyf/core-introduction-to-tries)
-        - [ ] [Performance Of Tries (video)](https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/PvlZW/core-performance-of-tries)
-        - [ ] [Implementing A Trie (video)](https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/DFvd3/core-implementing-a-trie)
-    - [ ] [The Trie: A Neglected Data Structure](https://www.toptal.com/java/the-trie-a-neglected-data-structure)
-    - [ ] [TopCoder - Using Tries](https://www.topcoder.com/thrive/articles/Using%20Tries)
-    - [ ] [Stanford Lecture (real-world use case) (video)](https://www.youtube.com/watch?v=TJ8SkcUSdbU)
-    - [ ] [MIT, Advanced Data Structures, Strings (can get pretty obscure about halfway through) (video)](https://www.youtube.com/watch?v=NinWEPPrkDQ&index=16&list=PLUl4u3cNGP61hsJNdULdudlRL493b-XZf)
+        - [ ] <a href="https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/08Xyf/core-introduction-to-tries" target="_blank">Introduction To Tries (video)</a>
+        - [ ] <a href="https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/PvlZW/core-performance-of-tries" target="_blank">Performance Of Tries (video)</a>
+        - [ ] <a href="https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/DFvd3/core-implementing-a-trie" target="_blank">Implementing A Trie (video)</a>
+    - [ ] <a href="https://www.toptal.com/java/the-trie-a-neglected-data-structure" target="_blank">The Trie: A Neglected Data Structure</a>
+    - [ ] <a href="https://www.topcoder.com/thrive/articles/Using%20Tries" target="_blank">TopCoder - Using Tries</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=TJ8SkcUSdbU" target="_blank">Stanford Lecture (real-world use case) (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=NinWEPPrkDQ&index=16&list=PLUl4u3cNGP61hsJNdULdudlRL493b-XZf" target="_blank">MIT, Advanced Data Structures, Strings (can get pretty obscure about halfway through) (video)</a>
 
 - ### Floating Point Numbers
-    - [ ] simple 8-bit: [Representation of Floating Point Numbers - 1 (video - there is an error in calculations - see video description)](https://www.youtube.com/watch?v=ji3SfClm8TU)
+    - [ ] simple 8-bit: <a href="https://www.youtube.com/watch?v=ji3SfClm8TU" target="_blank">Representation of Floating Point Numbers - 1 (video - there is an error in calculations - see video description)</a>
 
 - ### Unicode
-    - [ ] [The Absolute Minimum Every Software Developer Absolutely, Positively Must Know About Unicode and Character Sets]( http://www.joelonsoftware.com/articles/Unicode.html)
-    - [ ] [What Every Programmer Absolutely, Positively Needs To Know About Encodings And Character Sets To Work With Text](http://kunststube.net/encoding/)
+    - [ ] <a href="http://www.joelonsoftware.com/articles/Unicode.html" target="_blank">The Absolute Minimum Every Software Developer Absolutely, Positively Must Know About Unicode and Character Sets</a>
+    - [ ] <a href="http://kunststube.net/encoding/" target="_blank">What Every Programmer Absolutely, Positively Needs To Know About Encodings And Character Sets To Work With Text</a>
 
 - ### Endianness
-    - [ ] [Big And Little Endian](https://web.archive.org/web/20180107141940/http://www.cs.umd.edu:80/class/sum2003/cmsc311/Notes/Data/endian.html)
-    - [ ] [Big Endian Vs Little Endian (video)](https://www.youtube.com/watch?v=JrNF0KRAlyo)
-    - [ ] [Big And Little Endian Inside/Out (video)](https://www.youtube.com/watch?v=oBSuXP-1Tc0)
+    - [ ] <a href="https://web.archive.org/web/20180107141940/http://www.cs.umd.edu:80/class/sum2003/cmsc311/Notes/Data/endian.html" target="_blank">Big And Little Endian</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=JrNF0KRAlyo" target="_blank">Big Endian Vs Little Endian (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=oBSuXP-1Tc0" target="_blank">Big And Little Endian Inside/Out (video)</a>
         - Very technical talk for kernel devs. Don't worry if most is over your head.
         - The first half is enough.
 
 - ### Networking
     - **If you have networking experience or want to be a reliability engineer or operations engineer, expect questions**
     - Otherwise, this is just good to know
-    - [ ] [Khan Academy](https://www.khanacademy.org/computing/code-org/computers-and-the-internet)
-    - [ ] [UDP and TCP: Comparison of Transport Protocols (video)](https://www.youtube.com/watch?v=Vdc8TCESIg8)
-    - [ ] [TCP/IP and the OSI Model Explained! (video)](https://www.youtube.com/watch?v=e5DEVa9eSN0)
-    - [ ] [Packet Transmission across the Internet. Networking & TCP/IP tutorial. (video)](https://www.youtube.com/watch?v=nomyRJehhnM)
-    - [ ] [HTTP (video)](https://www.youtube.com/watch?v=WGJrLqtX7As)
-    - [ ] [SSL and HTTPS (video)](https://www.youtube.com/watch?v=S2iBR2ZlZf0)
-    - [ ] [SSL/TLS (video)](https://www.youtube.com/watch?v=Rp3iZUvXWlM)
-    - [ ] [HTTP 2.0 (video)](https://www.youtube.com/watch?v=E9FxNzv1Tr8)
-    - [ ] [Video Series (21 videos) (video)](https://www.youtube.com/playlist?list=PLEbnTDJUr_IegfoqO4iPnPYQui46QqT0j)
-    - [ ] [Subnetting Demystified - Part 5 CIDR Notation (video)](https://www.youtube.com/watch?v=t5xYI0jzOf4)
+    - [ ] <a href="https://www.khanacademy.org/computing/code-org/computers-and-the-internet" target="_blank">Khan Academy</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=Vdc8TCESIg8" target="_blank">UDP and TCP: Comparison of Transport Protocols (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=e5DEVa9eSN0" target="_blank">TCP/IP and the OSI Model Explained! (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=nomyRJehhnM" target="_blank">Packet Transmission across the Internet. Networking & TCP/IP tutorial. (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=WGJrLqtX7As" target="_blank">HTTP (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=S2iBR2ZlZf0" target="_blank">SSL and HTTPS (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=Rp3iZUvXWlM" target="_blank">SSL/TLS (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=E9FxNzv1Tr8" target="_blank">HTTP 2.0 (video)</a>
+    - [ ] <a href="https://www.youtube.com/playlist?list=PLEbnTDJUr_IegfoqO4iPnPYQui46QqT0j" target="_blank">Video Series (21 videos) (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=t5xYI0jzOf4" target="_blank">Subnetting Demystified - Part 5 CIDR Notation (video)</a>
     - [ ] Sockets:
-        - [ ] [Java - Sockets - Introduction (video)](https://www.youtube.com/watch?v=6G_W54zuadg&t=6s)
-        - [ ] [Socket Programming (video)](https://www.youtube.com/watch?v=G75vN2mnJeQ)
+        - [ ] <a href="https://www.youtube.com/watch?v=6G_W54zuadg&t=6s" target="_blank">Java - Sockets - Introduction (video)</a>
+        - [ ] <a href="https://www.youtube.com/watch?v=G75vN2mnJeQ" target="_blank">Socket Programming (video)</a>
 
 ---
 
@@ -1230,59 +1231,59 @@ Graphs can be used to represent many problems in computer science, so this secti
     It's nice if you want a refresher often.
 
 - [ ] Series of 2-3 minutes short subject videos (23 videos)
-    - [Videos](https://www.youtube.com/watch?v=r4r1DZcx1cM&list=PLmVb1OknmNJuC5POdcDv5oCS7_OUkDgpj&index=22)
+    - <a href="https://www.youtube.com/watch?v=r4r1DZcx1cM&list=PLmVb1OknmNJuC5POdcDv5oCS7_OUkDgpj&index=22" target="_blank">Videos</a>
 - [ ] Series of 2-5 minutes short subject videos - Michael Sambol (48 videos):
-    - [Videos](https://www.youtube.com/@MichaelSambol)
-    - [Code Examples](https://github.com/msambol/dsa)
-- [ ] [Sedgewick Videos - Algorithms I](https://www.coursera.org/learn/algorithms-part1)
-- [ ] [Sedgewick Videos - Algorithms II](https://www.coursera.org/learn/algorithms-part2)
+    - <a href="https://www.youtube.com/@MichaelSambol" target="_blank">Videos</a>
+    - <a href="https://github.com/msambol/dsa" target="_blank">Code Examples</a>
+- [ ] <a href="https://www.coursera.org/learn/algorithms-part1" target="_blank">Sedgewick Videos - Algorithms I</a>
+- [ ] <a href="https://www.coursera.org/learn/algorithms-part2" target="_blank">Sedgewick Videos - Algorithms II</a>
 
 ---
 
-**[⬆ back to top](#table-of-contents)**
+<strong><a href="#table-of-contents" target="_blank">⬆ back to top</a></strong>
 
 ## Update Your Resume
 
 - See Resume prep information in the books: "Cracking The Coding Interview" and "Programming Interviews Exposed"
-- ["This Is What A GOOD Resume Should Look Like" by Gayle McDowell (author of Cracking the Coding Interview)](https://www.careercup.com/resume),
+- <a href="https://www.careercup.com/resume" target="_blank">"This Is What A GOOD Resume Should Look Like" by Gayle McDowell (author of Cracking the Coding Interview)</a>,
     - Note by the author: "This is for a US-focused resume. CVs for India and other countries have different expectations, although many of the points will be the same."
-- ["Step-by-step resume guide" by Tech Interview Handbook](https://www.techinterviewhandbook.org/resume/guide)
+- <a href="https://www.techinterviewhandbook.org/resume/guide" target="_blank">"Step-by-step resume guide" by Tech Interview Handbook</a>
     - Detailed guide on how to set up your resume from scratch, write effective resume content, optimize it, and test your resume
 
-**[⬆ back to top](#table-of-contents)**
+<strong><a href="#table-of-contents" target="_blank">⬆ back to top</a></strong>
 
 ## Interview Process & General Interview Prep
 
-- [ ] [How to Pass the Engineering Interview in 2021](https://davidbyttow.medium.com/how-to-pass-the-engineering-interview-in-2021-45f1b389a1)
-- [ ] [Demystifying Tech Recruiting](https://www.youtube.com/watch?v=N233T0epWTs)
+- [ ] <a href="https://davidbyttow.medium.com/how-to-pass-the-engineering-interview-in-2021-45f1b389a1" target="_blank">How to Pass the Engineering Interview in 2021</a>
+- [ ] <a href="https://www.youtube.com/watch?v=N233T0epWTs" target="_blank">Demystifying Tech Recruiting</a>
 - [ ] How to Get a Job at the Big 4:
-    - [ ] [How to Get a Job at the Big 4 - Amazon, Facebook, Google & Microsoft (video)](https://www.youtube.com/watch?v=YJZCUhxNCv8)
-    - [ ] [How to Get a Job at the Big 4.1 (Follow-up video)](https://www.youtube.com/watch?v=6790FVXWBw8&feature=youtu.be)
+    - [ ] <a href="https://www.youtube.com/watch?v=YJZCUhxNCv8" target="_blank">How to Get a Job at the Big 4 - Amazon, Facebook, Google & Microsoft (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=6790FVXWBw8&feature=youtu.be" target="_blank">How to Get a Job at the Big 4.1 (Follow-up video)</a>
 - [ ] Cracking The Coding Interview Set 1:
-    - [ ] [Gayle L McDowell - Cracking The Coding Interview (video)](https://www.youtube.com/watch?v=rEJzOhC5ZtQ)
-    - [ ] [Cracking the Coding Interview with Author Gayle Laakmann McDowell (video)](https://www.youtube.com/watch?v=aClxtDcdpsQ)
+    - [ ] <a href="https://www.youtube.com/watch?v=rEJzOhC5ZtQ" target="_blank">Gayle L McDowell - Cracking The Coding Interview (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=aClxtDcdpsQ" target="_blank">Cracking the Coding Interview with Author Gayle Laakmann McDowell (video)</a>
 - [ ] Cracking the Facebook Coding Interview:
-    - [ ] [The Approach](https://www.youtube.com/watch?v=wCl9kvQGHPI)
-    - [ ] [Problem Walkthrough](https://www.youtube.com/watch?v=4UWDyJq8jZg)
+    - [ ] <a href="https://www.youtube.com/watch?v=wCl9kvQGHPI" target="_blank">The Approach</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=4UWDyJq8jZg" target="_blank">Problem Walkthrough</a>
 - Prep Courses:
-    - [Python for Data Structures, Algorithms, and Interviews (paid course)](https://www.udemy.com/python-for-data-structures-algorithms-and-interviews/):
+    - <a href="https://www.udemy.com/python-for-data-structures-algorithms-and-interviews/" target="_blank">Python for Data Structures, Algorithms, and Interviews (paid course)</a>:
         - A Python-centric interview prep course that covers data structures, algorithms, mock interviews, and much more.
-    - [Intro to Data Structures and Algorithms using Python (Udacity free course)](https://www.udacity.com/course/data-structures-and-algorithms-in-python--ud513):
+    - <a href="https://www.udacity.com/course/data-structures-and-algorithms-in-python--ud513" target="_blank">Intro to Data Structures and Algorithms using Python (Udacity free course)</a>:
         - A free Python-centric data structures and algorithms course.
-    - [Data Structures and Algorithms Nanodegree! (Udacity paid Nanodegree)](https://www.udacity.com/course/data-structures-and-algorithms-nanodegree--nd256):
+    - <a href="https://www.udacity.com/course/data-structures-and-algorithms-nanodegree--nd256" target="_blank">Data Structures and Algorithms Nanodegree! (Udacity paid Nanodegree)</a>:
         - Get hands-on practice with over 100 data structures and algorithm exercises and guidance from a dedicated mentor to help prepare you for interviews and on-the-job scenarios.
-    - [Grokking the Behavioral Interview (Educative free course)](https://www.educative.io/courses/grokking-the-behavioral-interview):
+    - <a href="https://www.educative.io/courses/grokking-the-behavioral-interview" target="_blank">Grokking the Behavioral Interview (Educative free course)</a>:
         - Many times, it’s not your technical competency that holds you back from landing your dream job, it’s how you perform on the behavioral interview.
-    - [AlgoMonster (paid course with free content)](https://algo.monster/?utm_campaign=jwasham&utm_medium=referral&utm_content=coding-interview-university&utm_source=github):
+    - <a href="https://algo.monster/?utm_campaign=jwasham&utm_medium=referral&utm_content=coding-interview-university&utm_source=github" target="_blank">AlgoMonster (paid course with free content)</a>:
       - The crash course for LeetCode. Covers all the patterns condensed from thousands of questions.
 
 Mock Interviews:
-- [Gainlo.co: Mock interviewers from big companies](http://www.gainlo.co/#!/) - I used this and it helped me relax for the phone screen and on-site interview
-- [Pramp: Mock interviews from/with peers](https://www.pramp.com/) - a peer-to-peer model to practice interviews
-- [interviewing.io: Practice mock interview with senior engineers](https://interviewing.io) - anonymous algorithmic/systems design interviews with senior engineers from FAANG anonymously
-- [Meetapro: Mock interviews with top FAANG interviewers](https://meetapro.com/?utm_source=ciu) - an Airbnb-style mock interview/coaching platform.
-- [Hello Interview: Mock Interviews with Expert Coaches and AI](https://www.hellointerview.com/?utm_source=ciu) - interview directly with AI or with FAANG staff engineers and managers.
-- [Codemia: Practice system design problems with AI or community solutions and feedback](https://codemia.io/?utm_source=ciu) - Practice system design problems via AI practice tool. Share your solution with the community to get human feedback as well.
+- <a href="http://www.gainlo.co/#!/" target="_blank">Gainlo.co: Mock interviewers from big companies</a> - I used this and it helped me relax for the phone screen and on-site interview
+- <a href="https://www.pramp.com/" target="_blank">Pramp: Mock interviews from/with peers</a> - a peer-to-peer model to practice interviews
+- <a href="https://interviewing.io" target="_blank">interviewing.io: Practice mock interview with senior engineers</a> - anonymous algorithmic/systems design interviews with senior engineers from FAANG anonymously
+- <a href="https://meetapro.com/?utm_source=ciu" target="_blank">Meetapro: Mock interviews with top FAANG interviewers</a> - an Airbnb-style mock interview/coaching platform.
+- <a href="https://www.hellointerview.com/?utm_source=ciu" target="_blank">Hello Interview: Mock Interviews with Expert Coaches and AI</a> - interview directly with AI or with FAANG staff engineers and managers.
+- <a href="https://codemia.io/?utm_source=ciu" target="_blank">Codemia: Practice system design problems with AI or community solutions and feedback</a> - Practice system design problems via AI practice tool. Share your solution with the community to get human feedback as well.
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -1351,17 +1352,17 @@ You're never really done.
 
     These are here so you can dive into a topic you find interesting.
 
-- [The Unix Programming Environment](https://www.amazon.com/dp/013937681X)
+- <a href="https://www.amazon.com/dp/013937681X" target="_blank">The Unix Programming Environment</a>
     - An oldie but a goodie
-- [The Linux Command Line: A Complete Introduction](https://www.amazon.com/dp/1593273894/)
+- <a href="https://www.amazon.com/dp/1593273894/" target="_blank">The Linux Command Line: A Complete Introduction</a>
     - A modern option
-- [TCP/IP Illustrated Series](https://en.wikipedia.org/wiki/TCP/IP_Illustrated)
-- [Head First Design Patterns](https://www.amazon.com/gp/product/0596007124/)
+- <a href="https://en.wikipedia.org/wiki/TCP/IP_Illustrated" target="_blank">TCP/IP Illustrated Series</a>
+- <a href="https://www.amazon.com/gp/product/0596007124/" target="_blank">Head First Design Patterns</a>
     - A gentle introduction to design patterns
-- [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612)
+- <a href="https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612" target="_blank">Design Patterns: Elements of Reusable Object-Oriented Software</a>
     - AKA the "Gang Of Four" book or GOF
     - The canonical design patterns book
-- [Algorithm Design Manual](http://www.amazon.com/Algorithm-Design-Manual-Steven-Skiena/dp/1849967202) (Skiena)
+- <a href="http://www.amazon.com/Algorithm-Design-Manual-Steven-Skiena/dp/1849967202" target="_blank">Algorithm Design Manual</a> (Skiena)
     - As a review and problem-recognition
     - The algorithm catalog portion is well beyond the scope of difficulty you'll get in an interview
     - This book has 2 parts:
@@ -1379,12 +1380,12 @@ You're never really done.
             - This book is better as an algorithm reference, and not something you read cover to cover.
     - Can rent it on Kindle
     - Answers:
-        - [Solutions](https://web.archive.org/web/20150404194210/http://www.algorithm.cs.sunysb.edu/algowiki/index.php/The_Algorithms_Design_Manual_(Second_Edition))
-    - [Errata](http://www3.cs.stonybrook.edu/~skiena/algorist/book/errata)
-- [Algorithm](http://jeffe.cs.illinois.edu/teaching/algorithms/) (Jeff Erickson)
-- [Write Great Code: Volume 1: Understanding the Machine](https://www.amazon.com/Write-Great-Code-Understanding-Machine/dp/1593270038)
+        - <a href="https://web.archive.org/web/20150404194210/http://www.algorithm.cs.sunysb.edu/algowiki/index.php/The_Algorithms_Design_Manual_(Second_Edition)" target="_blank">Solutions</a>
+    - <a href="http://www3.cs.stonybrook.edu/~skiena/algorist/book/errata" target="_blank">Errata</a>
+- <a href="http://jeffe.cs.illinois.edu/teaching/algorithms/" target="_blank">Algorithm</a> (Jeff Erickson)
+- <a href="https://www.amazon.com/Write-Great-Code-Understanding-Machine/dp/1593270038" target="_blank">Write Great Code: Volume 1: Understanding the Machine</a>
     - The book was published in 2004, and is somewhat outdated, but it's a terrific resource for understanding a computer in brief
-    - The author invented [HLA](https://en.wikipedia.org/wiki/High_Level_Assembly), so take mentions and examples in HLA with a grain of salt. Not widely used, but decent examples of what assembly looks like
+    - The author invented <a href="https://en.wikipedia.org/wiki/High_Level_Assembly" target="_blank">HLA</a>, so take mentions and examples in HLA with a grain of salt. Not widely used, but decent examples of what assembly looks like
     - These chapters are worth the read to give you a nice foundation:
         - Chapter 2 - Numeric Representation
         - Chapter 3 - Binary Arithmetic and Bit Operations
@@ -1395,12 +1396,12 @@ You're never really done.
         - Chapter 9 - CPU Architecture
         - Chapter 10 - Instruction Set Architecture
         - Chapter 11 - Memory Architecture and Organization
-- [Introduction to Algorithms](https://www.amazon.com/Introduction-Algorithms-fourth-Thomas-Cormen/dp/026204630X)
+- <a href="https://www.amazon.com/Introduction-Algorithms-fourth-Thomas-Cormen/dp/026204630X" target="_blank">Introduction to Algorithms</a>
     - **Important:** Reading this book will only have limited value. This book is a great review of algorithms and data structures, but won't teach you how to write good code. You have to be able to code a decent solution efficiently
     - AKA CLR, sometimes CLRS, because Stein was late to the game
-- [Computer Architecture, Sixth Edition: A Quantitative Approach](https://www.amazon.com/dp/0128119055)
+- <a href="https://www.amazon.com/dp/0128119055" target="_blank">Computer Architecture, Sixth Edition: A Quantitative Approach</a>
     - For a richer, more up-to-date (2017), but longer treatment
-
+      
 **[⬆ back to top](#table-of-contents)**
 
 ## System Design, Scalability, Data Handling
@@ -1423,71 +1424,71 @@ You're never really done.
         - simplicity and robustness
         - tradeoffs
         - performance analysis and optimization
-- [ ] **START HERE**: [The System Design Primer](https://github.com/donnemartin/system-design-primer)
-- [ ] [System Design from HiredInTech](http://www.hiredintech.com/system-design/)
-- [ ] [How Do I Prepare To Answer Design Questions In A Technical Interview?](https://www.quora.com/How-do-I-prepare-to-answer-design-questions-in-a-technical-interview?redirected_qid=1500023)
-- [ ] [8 steps guide to ace your system design interview](https://javascript.plainenglish.io/8-steps-guide-to-ace-a-system-design-interview-7a5a797f4d7d)
-- [ ] [Database Normalization - 1NF, 2NF, 3NF and 4NF (video)](https://www.youtube.com/watch?v=UrYLYV7WSHM)
-- [ ] [System Design Interview](https://github.com/checkcheckzz/system-design-interview) - There are a lot of resources in this one. Look through the articles and examples. I put some of them below
-- [ ] [How to ace a systems design interview](https://web.archive.org/web/20120716060051/http://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/)
-- [ ] [Numbers Everyone Should Know](http://everythingisdata.wordpress.com/2009/10/17/numbers-everyone-should-know/)
-- [ ] [How long does it take to make a context switch?](http://blog.tsunanet.net/2010/11/how-long-does-it-take-to-make-context.html)
-- [ ] [Transactions Across Datacenters (video)](https://www.youtube.com/watch?v=srOgpXECblk)
-- [ ] [A plain English introduction to CAP Theorem](http://ksat.me/a-plain-english-introduction-to-cap-theorem)
-- [ ] [MIT 6.824: Distributed Systems, Spring 2020 (20 videos)](https://www.youtube.com/watch?v=cQP8WApzIQQ&list=PLrw6a1wE39_tb2fErI4-WkMbsvGQk9_UB)
+- [ ] **START HERE**: <a href="https://github.com/donnemartin/system-design-primer" target="_blank">The System Design Primer</a>
+- [ ] <a href="http://www.hiredintech.com/system-design/" target="_blank">System Design from HiredInTech</a>
+- [ ] <a href="https://www.quora.com/How-do-I-prepare-to-answer-design-questions-in-a-technical-interview?redirected_qid=1500023" target="_blank">How Do I Prepare To Answer Design Questions In A Technical Interview?</a>
+- [ ] <a href="https://javascript.plainenglish.io/8-steps-guide-to-ace-a-system-design-interview-7a5a797f4d7d" target="_blank">8 steps guide to ace your system design interview</a>
+- [ ] <a href="https://www.youtube.com/watch?v=UrYLYV7WSHM" target="_blank">Database Normalization - 1NF, 2NF, 3NF and 4NF (video)</a>
+- [ ] <a href="https://github.com/checkcheckzz/system-design-interview" target="_blank">System Design Interview</a> - There are a lot of resources in this one. Look through the articles and examples. I put some of them below
+- [ ] <a href="https://web.archive.org/web/20120716060051/http://www.palantir.com/2011/10/how-to-rock-a-systems-design-interview/" target="_blank">How to ace a systems design interview</a>
+- [ ] <a href="http://everythingisdata.wordpress.com/2009/10/17/numbers-everyone-should-know/" target="_blank">Numbers Everyone Should Know</a>
+- [ ] <a href="http://blog.tsunanet.net/2010/11/how-long-does-it-take-to-make-context.html" target="_blank">How long does it take to make a context switch?</a>
+- [ ] <a href="https://www.youtube.com/watch?v=srOgpXECblk" target="_blank">Transactions Across Datacenters (video)</a>
+- [ ] <a href="http://ksat.me/a-plain-english-introduction-to-cap-theorem" target="_blank">A plain English introduction to CAP Theorem</a>
+- [ ] <a href="https://www.youtube.com/watch?v=cQP8WApzIQQ&list=PLrw6a1wE39_tb2fErI4-WkMbsvGQk9_UB" target="_blank">MIT 6.824: Distributed Systems, Spring 2020 (20 videos)</a>
 - [ ] Consensus Algorithms:
-    - [ ] Paxos - [Paxos Agreement - Computerphile (video)](https://www.youtube.com/watch?v=s8JqcZtvnsM)
-    - [ ] Raft - [An Introduction to the Raft Distributed Consensus Algorithm (video)](https://www.youtube.com/watch?v=P9Ydif5_qvE)
-        - [ ] [Easy-to-read paper](https://raft.github.io/)
-        - [ ] [Infographic](http://thesecretlivesofdata.com/raft/)
-- [ ] [Consistent Hashing](http://www.tom-e-white.com/2007/11/consistent-hashing.html)
-- [ ] [NoSQL Patterns](http://horicky.blogspot.com/2009/11/nosql-patterns.html)
+    - [ ] Paxos - <a href="https://www.youtube.com/watch?v=s8JqcZtvnsM" target="_blank">Paxos Agreement - Computerphile (video)</a>
+    - [ ] Raft - <a href="https://www.youtube.com/watch?v=P9Ydif5_qvE" target="_blank">An Introduction to the Raft Distributed Consensus Algorithm (video)</a>
+        - [ ] <a href="https://raft.github.io/" target="_blank">Easy-to-read paper</a>
+        - [ ] <a href="http://thesecretlivesofdata.com/raft/" target="_blank">Infographic</a>
+- [ ] <a href="http://www.tom-e-white.com/2007/11/consistent-hashing.html" target="_blank">Consistent Hashing</a>
+- [ ] <a href="http://horicky.blogspot.com/2009/11/nosql-patterns.html" target="_blank">NoSQL Patterns</a>
 - [ ] Scalability:
     - You don't need all of these. Just pick a few that interest you.
-    - [ ] [Great overview (video)](https://www.youtube.com/watch?v=-W9F__D3oY4)
+    - [ ] <a href="https://www.youtube.com/watch?v=-W9F__D3oY4" target="_blank">Great overview (video)</a>
     - [ ] Short series:
-        - [Clones](http://www.lecloud.net/post/7295452622/scalability-for-dummies-part-1-clones)
-        - [Database](http://www.lecloud.net/post/7994751381/scalability-for-dummies-part-2-database)
-        - [Cache](http://www.lecloud.net/post/9246290032/scalability-for-dummies-part-3-cache)
-        - [Asynchronism](http://www.lecloud.net/post/9699762917/scalability-for-dummies-part-4-asynchronism)
-    - [ ] [Scalable Web Architecture and Distributed Systems](http://www.aosabook.org/en/distsys.html)
-    - [ ] [Fallacies of Distributed Computing Explained](https://pages.cs.wisc.edu/~zuyu/files/fallacies.pdf)
-    - [ ] [Jeff Dean - Building Software Systems At Google and Lessons Learned (video)](https://www.youtube.com/watch?v=modXC5IWTJI)
-    - [ ] [Introduction to Architecting Systems for Scale](http://lethain.com/introduction-to-architecting-systems-for-scale/)
-    - [ ] [Scaling mobile games to a global audience using App Engine and Cloud Datastore (video)](https://www.youtube.com/watch?v=9nWyWwY2Onc)
-    - [ ] [How Google Does Planet-Scale Engineering for Planet-Scale Infra (video)](https://www.youtube.com/watch?v=H4vMcD7zKM0)
-    - [ ] [The Importance of Algorithms](https://www.topcoder.com/thrive/articles/The%20Importance%20of%20Algorithms)
-    - [ ] [Sharding](http://highscalability.com/blog/2009/8/6/an-unorthodox-approach-to-database-design-the-coming-of-the.html)
-    - [ ] [Engineering for the Long Game - Astrid Atkinson Keynote(video)](https://www.youtube.com/watch?v=p0jGmgIrf_M&list=PLRXxvay_m8gqVlExPC5DG3TGWJTaBgqSA&index=4)
-    - [ ] [7 Years Of YouTube Scalability Lessons In 30 Minutes](http://highscalability.com/blog/2012/3/26/7-years-of-youtube-scalability-lessons-in-30-minutes.html)
-        - [video](https://www.youtube.com/watch?v=G-lGCC4KKok)
-    - [ ] [How PayPal Scaled To Billions Of Transactions Daily Using Just 8VMs](http://highscalability.com/blog/2016/8/15/how-paypal-scaled-to-billions-of-transactions-daily-using-ju.html)
-    - [ ] [How to Remove Duplicates in Large Datasets](https://blog.clevertap.com/how-to-remove-duplicates-in-large-datasets/)
-    - [ ] [A look inside Etsy's scale and engineering culture with Jon Cowie (video)](https://www.youtube.com/watch?v=3vV4YiqKm1o)
-    - [ ] [What Led Amazon to its Own Microservices Architecture](http://thenewstack.io/led-amazon-microservices-architecture/)
-    - [ ] [To Compress Or Not To Compress, That Was Uber's Question](https://eng.uber.com/trip-data-squeeze/)
-    - [ ] [When Should Approximate Query Processing Be Used?](http://highscalability.com/blog/2016/2/25/when-should-approximate-query-processing-be-used.html)
-    - [ ] [Google's Transition From Single Datacenter To Failover, To A Native Multihomed Architecture]( http://highscalability.com/blog/2016/2/23/googles-transition-from-single-datacenter-to-failover-to-a-n.html)
-    - [ ] [The Image Optimization Technology That Serves Millions Of Requests Per Day](http://highscalability.com/blog/2016/6/15/the-image-optimization-technology-that-serves-millions-of-re.html)
-    - [ ] [A Patreon Architecture Short](http://highscalability.com/blog/2016/2/1/a-patreon-architecture-short.html)
-    - [ ] [Tinder: How Does One Of The Largest Recommendation Engines Decide Who You'll See Next?](http://highscalability.com/blog/2016/1/27/tinder-how-does-one-of-the-largest-recommendation-engines-de.html)
-    - [ ] [Design Of A Modern Cache](http://highscalability.com/blog/2016/1/25/design-of-a-modern-cache.html)
-    - [ ] [Live Video Streaming At Facebook Scale](http://highscalability.com/blog/2016/1/13/live-video-streaming-at-facebook-scale.html)
-    - [ ] [A Beginner's Guide To Scaling To 11 Million+ Users On Amazon's AWS](http://highscalability.com/blog/2016/1/11/a-beginners-guide-to-scaling-to-11-million-users-on-amazons.html)
-    - [ ] [A 360 Degree View Of The Entire Netflix Stack](http://highscalability.com/blog/2015/11/9/a-360-degree-view-of-the-entire-netflix-stack.html)
-    - [ ] [Latency Is Everywhere And It Costs You Sales - How To Crush It](http://highscalability.com/latency-everywhere-and-it-costs-you-sales-how-crush-it)
-    - [ ] [What Powers Instagram: Hundreds of Instances, Dozens of Technologies](http://instagram-engineering.tumblr.com/post/13649370142/what-powers-instagram-hundreds-of-instances)
-    - [ ] [Salesforce Architecture - How They Handle 1.3 Billion Transactions A Day](http://highscalability.com/blog/2013/9/23/salesforce-architecture-how-they-handle-13-billion-transacti.html)
-    - [ ] [ESPN's Architecture At Scale - Operating At 100,000 Duh Nuh Nuhs Per Second](http://highscalability.com/blog/2013/11/4/espns-architecture-at-scale-operating-at-100000-duh-nuh-nuhs.html)
+        - <a href="http://www.lecloud.net/post/7295452622/scalability-for-dummies-part-1-clones" target="_blank">Clones</a>
+        - <a href="http://www.lecloud.net/post/7994751381/scalability-for-dummies-part-2-database" target="_blank">Database</a>
+        - <a href="http://www.lecloud.net/post/9246290032/scalability-for-dummies-part-3-cache" target="_blank">Cache</a>
+        - <a href="http://www.lecloud.net/post/9699762917/scalability-for-dummies-part-4-asynchronism" target="_blank">Asynchronism</a>
+    - [ ] <a href="http://www.aosabook.org/en/distsys.html" target="_blank">Scalable Web Architecture and Distributed Systems</a>
+    - [ ] <a href="https://pages.cs.wisc.edu/~zuyu/files/fallacies.pdf" target="_blank">Fallacies of Distributed Computing Explained</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=modXC5IWTJI" target="_blank">Jeff Dean - Building Software Systems At Google and Lessons Learned (video)</a>
+    - [ ] <a href="http://lethain.com/introduction-to-architecting-systems-for-scale/" target="_blank">Introduction to Architecting Systems for Scale</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=9nWyWwY2Onc" target="_blank">Scaling mobile games to a global audience using App Engine and Cloud Datastore (video)</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=H4vMcD7zKM0" target="_blank">How Google Does Planet-Scale Engineering for Planet-Scale Infra (video)</a>
+    - [ ] <a href="https://www.topcoder.com/thrive/articles/The%20Importance%20of%20Algorithms" target="_blank">The Importance of Algorithms</a>
+    - [ ] <a href="http://highscalability.com/blog/2009/8/6/an-unorthodox-approach-to-database-design-the-coming-of-the.html" target="_blank">Sharding</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=p0jGmgIrf_M&list=PLRXxvay_m8gqVlExPC5DG3TGWJTaBgqSA&index=4" target="_blank">Engineering for the Long Game - Astrid Atkinson Keynote(video)</a>
+    - [ ] <a href="http://highscalability.com/blog/2012/3/26/7-years-of-youtube-scalability-lessons-in-30-minutes.html" target="_blank">7 Years Of YouTube Scalability Lessons In 30 Minutes</a>
+        - <a href="https://www.youtube.com/watch?v=G-lGCC4KKok" target="_blank">video</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/8/15/how-paypal-scaled-to-billions-of-transactions-daily-using-ju.html" target="_blank">How PayPal Scaled To Billions Of Transactions Daily Using Just 8VMs</a>
+    - [ ] <a href="https://blog.clevertap.com/how-to-remove-duplicates-in-large-datasets/" target="_blank">How to Remove Duplicates in Large Datasets</a>
+    - [ ] <a href="https://www.youtube.com/watch?v=3vV4YiqKm1o" target="_blank">A look inside Etsy's scale and engineering culture with Jon Cowie (video)</a>
+    - [ ] <a href="http://thenewstack.io/led-amazon-microservices-architecture/" target="_blank">What Led Amazon to its Own Microservices Architecture</a>
+    - [ ] <a href="https://eng.uber.com/trip-data-squeeze/" target="_blank">To Compress Or Not To Compress, That Was Uber's Question</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/2/25/when-should-approximate-query-processing-be-used.html" target="_blank">When Should Approximate Query Processing Be Used?</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/2/23/googles-transition-from-single-datacenter-to-failover-to-a-n.html" target="_blank">Google's Transition From Single Datacenter To Failover, To A Native Multihomed Architecture</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/6/15/the-image-optimization-technology-that-serves-millions-of-re.html" target="_blank">The Image Optimization Technology That Serves Millions Of Requests Per Day</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/2/1/a-patreon-architecture-short.html" target="_blank">A Patreon Architecture Short</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/1/27/tinder-how-does-one-of-the-largest-recommendation-engines-de.html" target="_blank">Tinder: How Does One Of The Largest Recommendation Engines Decide Who You'll See Next?</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/1/25/design-of-a-modern-cache.html" target="_blank">Design Of A Modern Cache</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/1/13/live-video-streaming-at-facebook-scale.html" target="_blank">Live Video Streaming At Facebook Scale</a>
+    - [ ] <a href="http://highscalability.com/blog/2016/1/11/a-beginners-guide-to-scaling-to-11-million-users-on-amazons.html" target="_blank">A Beginner's Guide To Scaling To 11 Million+ Users On Amazon's AWS</a>
+    - [ ] <a href="http://highscalability.com/blog/2015/11/9/a-360-degree-view-of-the-entire-netflix-stack.html" target="_blank">A 360 Degree View Of The Entire Netflix Stack</a>
+    - [ ] <a href="http://highscalability.com/latency-everywhere-and-it-costs-you-sales-how-crush-it" target="_blank">Latency Is Everywhere And It Costs You Sales - How To Crush It</a>
+    - [ ] <a href="http://instagram-engineering.tumblr.com/post/13649370142/what-powers-instagram-hundreds-of-instances" target="_blank">What Powers Instagram: Hundreds of Instances, Dozens of Technologies</a>
+    - [ ] <a href="http://highscalability.com/blog/2013/9/23/salesforce-architecture-how-they-handle-13-billion-transacti.html" target="_blank">Salesforce Architecture - How They Handle 1.3 Billion Transactions A Day</a>
+    - [ ] <a href="http://highscalability.com/blog/2013/11/4/espns-architecture-at-scale-operating-at-100000-duh-nuh-nuhs.html" target="_blank">ESPN's Architecture At Scale - Operating At 100,000 Duh Nuh Nuhs Per Second</a>
     - [ ] See "Messaging, Serialization, and Queueing Systems" way below for info on some of the technologies that can glue services together
     - [ ] Twitter:
-        - [O'Reilly MySQL CE 2011: Jeremy Cole, "Big and Small Data at @Twitter" (video)](https://www.youtube.com/watch?v=5cKTP36HVgI)
-        - [Timelines at Scale](https://www.infoq.com/presentations/Twitter-Timeline-Scalability)
-    - For even more, see the "Mining Massive Datasets" video series in the [Video Series](#video-series) section
+        - <a href="https://www.youtube.com/watch?v=5cKTP36HVgI" target="_blank">O'Reilly MySQL CE 2011: Jeremy Cole, "Big and Small Data at @Twitter" (video)</a>
+        - <a href="https://www.infoq.com/presentations/Twitter-Timeline-Scalability" target="_blank">Timelines at Scale</a>
+    - For even more, see the "Mining Massive Datasets" video series in the <a href="#video-series" target="_blank">Video Series</a> section
 - [ ] Practicing the system design process: Here are some ideas to try working through on paper, each with some documentation on how it was handled in the real world:
-    - review: [The System Design Primer](https://github.com/donnemartin/system-design-primer)
-    - [System Design from HiredInTech](http://www.hiredintech.com/system-design/)
-    - [cheat sheet](https://github.com/jwasham/coding-interview-university/blob/main/extras/cheat%20sheets/system-design.pdf)
+    - review: <a href="https://github.com/donnemartin/system-design-primer" target="_blank">The System Design Primer</a>
+    - <a href="http://www.hiredintech.com/system-design/" target="_blank">System Design from HiredInTech</a>
+    - <a href="https://github.com/jwasham/coding-interview-university/blob/main/extras/cheat%20sheets/system-design.pdf" target="_blank">cheat sheet</a>
     - flow:
         1. Understand the problem and scope:
             - Define the use cases, with the interviewer's help
@@ -1508,12 +1509,12 @@ You're never really done.
             - Rough overview of any key algorithm that drives the service
             - Consider bottlenecks and determine solutions
     - Exercises:
-        - [Design a random unique ID generation system](https://blog.twitter.com/2010/announcing-snowflake)
-        - [Design a key-value database](http://www.slideshare.net/dvirsky/introduction-to-redis)
-        - [Design a picture sharing system](http://highscalability.com/blog/2011/12/6/instagram-architecture-14-million-users-terabytes-of-photos.html)
-        - [Design a recommendation system](http://ijcai13.org/files/tutorial_slides/td3.pdf)
-        - [Design a URL-shortener system: copied from above](http://www.hiredintech.com/system-design/the-system-design-process/)
-        - [Design a cache system](https://web.archive.org/web/20220217064329/https://adayinthelifeof.nl/2011/02/06/memcache-internals/)
+        - <a href="https://blog.twitter.com/2010/announcing-snowflake" target="_blank">Design a random unique ID generation system</a>
+        - <a href="http://www.slideshare.net/dvirsky/introduction-to-redis" target="_blank">Design a key-value database</a>
+        - <a href="http://highscalability.com/blog/2011/12/6/instagram-architecture-14-million-users-terabytes-of-photos.html" target="_blank">Design a picture sharing system</a>
+        - <a href="http://ijcai13.org/files/tutorial_slides/td3.pdf" target="_blank">Design a recommendation system</a>
+        - <a href="http://www.hiredintech.com/system-design/the-system-design-process/" target="_blank">Design a URL-shortener system: copied from above</a>
+        - <a href="https://web.archive.org/web/20220217064329/https://adayinthelifeof.nl/2011/02/06/memcache-internals/" target="_blank">Design a cache system</a>
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -1523,32 +1524,32 @@ You're never really done.
     technologies and algorithms, so you'll have a bigger toolbox.
 
 - ### Compilers
-    - [How a Compiler Works in ~1 minute (video)](https://www.youtube.com/watch?v=IhC7sdYe-Jg)
-    - [Harvard CS50 - Compilers (video)](https://www.youtube.com/watch?v=CSZLNYF4Klo)
-    - [C++ (video)](https://www.youtube.com/watch?v=twodd1KFfGk)
-    - [Understanding Compiler Optimization (C++) (video)](https://www.youtube.com/watch?v=FnGCDLhaxKU)
+    - <a href="https://www.youtube.com/watch?v=IhC7sdYe-Jg" target="_blank">How a Compiler Works in ~1 minute (video)</a>
+    - <a href="https://www.youtube.com/watch?v=CSZLNYF4Klo" target="_blank">Harvard CS50 - Compilers (video)</a>
+    - <a href="https://www.youtube.com/watch?v=twodd1KFfGk" target="_blank">C++ (video)</a>
+    - <a href="https://www.youtube.com/watch?v=FnGCDLhaxKU" target="_blank">Understanding Compiler Optimization (C++) (video)</a>
 
 - ### Emacs and vi(m)
     - Familiarize yourself with a UNIX-based code editor
     - vi(m):
-        - [Editing With Vim 01 - Installation, Setup, and The Modes (video)](https://www.youtube.com/watch?v=5givLEMcINQ&index=1&list=PL13bz4SHGmRxlZVmWQ9DvXo1fEg4UdGkr)
-        - [VIM Adventures](http://vim-adventures.com/)
+        - <a href="https://www.youtube.com/watch?v=5givLEMcINQ&index=1&list=PL13bz4SHGmRxlZVmWQ9DvXo1fEg4UdGkr" target="_blank">Editing With Vim 01 - Installation, Setup, and The Modes (video)</a>
+        - <a href="http://vim-adventures.com/" target="_blank">VIM Adventures</a>
         - set of 4 videos:
-            - [The vi/vim editor - Lesson 1](https://www.youtube.com/watch?v=SI8TeVMX8pk)
-            - [The vi/vim editor - Lesson 2](https://www.youtube.com/watch?v=F3OO7ZIOaJE)
-            - [The vi/vim editor - Lesson 3](https://www.youtube.com/watch?v=ZYEccA_nMaI)
-            - [The vi/vim editor - Lesson 4](https://www.youtube.com/watch?v=1lYD5gwgZIA)
-        - [Using Vi Instead of Emacs](http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#Using_Vi_instead_of_Emacs)
+            - <a href="https://www.youtube.com/watch?v=SI8TeVMX8pk" target="_blank">The vi/vim editor - Lesson 1</a>
+            - <a href="https://www.youtube.com/watch?v=F3OO7ZIOaJE" target="_blank">The vi/vim editor - Lesson 2</a>
+            - <a href="https://www.youtube.com/watch?v=ZYEccA_nMaI" target="_blank">The vi/vim editor - Lesson 3</a>
+            - <a href="https://www.youtube.com/watch?v=1lYD5gwgZIA" target="_blank">The vi/vim editor - Lesson 4</a>
+        - <a href="http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#Using_Vi_instead_of_Emacs" target="_blank">Using Vi Instead of Emacs</a>
     - emacs:
-        - [Basics Emacs Tutorial (video)](https://www.youtube.com/watch?v=hbmV1bnQ-i0)
+        - <a href="https://www.youtube.com/watch?v=hbmV1bnQ-i0" target="_blank">Basics Emacs Tutorial (video)</a>
         - set of 3 (videos):
-            - [Emacs Tutorial (Beginners) -Part 1- File commands, cut/copy/paste, cursor commands](https://www.youtube.com/watch?v=ujODL7MD04Q)
-            - [Emacs Tutorial (Beginners) -Part 2- Buffer management, search, M-x grep and rgrep modes](https://www.youtube.com/watch?v=XWpsRupJ4II)
-            - [Emacs Tutorial (Beginners) -Part 3- Expressions, Statements, ~/.emacs file, and packages](https://www.youtube.com/watch?v=paSgzPso-yc)
-        - [Evil Mode: Or, How I Learned to Stop Worrying and Love Emacs (video)](https://www.youtube.com/watch?v=JWD1Fpdd4Pc)
-        - [Writing C Programs With Emacs](http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#Writing_C_programs_with_Emacs)
-	- [The Absolute Beginner's Guide to Emacs (video by David Wilson)](https://www.youtube.com/watch?v=48JlgiBpw_I&t=0s)
-	- [The Absolute Beginner's Guide to Emacs (notes by David Wilson)](https://systemcrafters.net/emacs-essentials/absolute-beginners-guide-to-emacs/)
+            - <a href="https://www.youtube.com/watch?v=ujODL7MD04Q" target="_blank">Emacs Tutorial (Beginners) -Part 1- File commands, cut/copy/paste, cursor commands</a>
+            - <a href="https://www.youtube.com/watch?v=XWpsRupJ4II" target="_blank">Emacs Tutorial (Beginners) -Part 2- Buffer management, search, M-x grep and rgrep modes</a>
+            - <a href="https://www.youtube.com/watch?v=paSgzPso-yc" target="_blank">Emacs Tutorial (Beginners) -Part 3- Expressions, Statements, ~/.emacs file, and packages</a>
+        - <a href="https://www.youtube.com/watch?v=JWD1Fpdd4Pc" target="_blank">Evil Mode: Or, How I Learned to Stop Worrying and Love Emacs (video)</a>
+        - <a href="http://www.cs.yale.edu/homes/aspnes/classes/223/notes.html#Writing_C_programs_with_Emacs" target="_blank">Writing C Programs With Emacs</a>
+	- <a href="https://www.youtube.com/watch?v=48JlgiBpw_I&t=0s" target="_blank">The Absolute Beginner's Guide to Emacs (video by David Wilson)</a>
+	- <a href="https://systemcrafters.net/emacs-essentials/absolute-beginners-guide-to-emacs/" target="_blank">The Absolute Beginner's Guide to Emacs (notes by David Wilson)</a>
 
 - ### Unix/Linux command line tools
     - I filled in the list below from good tools.
@@ -1561,131 +1562,131 @@ You're never really done.
     - sort
     - tr
     - uniq
-    - [strace](https://en.wikipedia.org/wiki/Strace)
-    - [tcpdump](https://danielmiessler.com/study/tcpdump/)
-    - [Essential Linux Commands Tutorial](https://labex.io/tutorials/practice-linux-commands-hands-on-labs-398420)
+    - <a href="https://en.wikipedia.org/wiki/Strace" target="_blank">strace</a>
+    - <a href="https://danielmiessler.com/study/tcpdump/" target="_blank">tcpdump</a>
+    - <a href="https://labex.io/tutorials/practice-linux-commands-hands-on-labs-398420" target="_blank">Essential Linux Commands Tutorial</a>
 
 - ### DevOps
-    - [DevOps Roadmap](https://roadmap.sh/devops)
+    - <a href="https://roadmap.sh/devops" target="_blank">DevOps Roadmap</a>
 
 - ### Information theory (videos)
-    - [Khan Academy](https://www.khanacademy.org/computing/computer-science/informationtheory)
+    - <a href="https://www.khanacademy.org/computing/computer-science/informationtheory" target="_blank">Khan Academy</a>
     - More about Markov processes:
-        - [Core Markov Text Generation](https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/waxgx/core-markov-text-generation)
-        - [Core Implementing Markov Text Generation](https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/gZhiC/core-implementing-markov-text-generation)
-        - [Project = Markov Text Generation Walk Through](https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/EUjrq/project-markov-text-generation-walk-through)
+        - <a href="https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/waxgx/core-markov-text-generation" target="_blank">Core Markov Text Generation</a>
+        - <a href="https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/gZhiC/core-implementing-markov-text-generation" target="_blank">Core Implementing Markov Text Generation</a>
+        - <a href="https://www.coursera.org/learn/data-structures-optimizing-performance/lecture/EUjrq/project-markov-text-generation-walk-through" target="_blank">Project = Markov Text Generation Walk Through</a>
     - See more in the MIT 6.050J Information and Entropy series below
 
 - ### Parity & Hamming Code (videos)
-    - [Intro](https://www.youtube.com/watch?v=q-3BctoUpHE)
-    - [Parity](https://www.youtube.com/watch?v=DdMcAUlxh1M)
+    - <a href="https://www.youtube.com/watch?v=q-3BctoUpHE" target="_blank">Intro</a>
+    - <a href="https://www.youtube.com/watch?v=DdMcAUlxh1M" target="_blank">Parity</a>
     - Hamming Code:
-        - [Error detection](https://www.youtube.com/watch?v=1A_NcXxdoCc)
-        - [Error correction](https://www.youtube.com/watch?v=JAMLuxdHH8o)
-    - [Error Checking](https://www.youtube.com/watch?v=wbH2VxzmoZk)
+        - <a href="https://www.youtube.com/watch?v=1A_NcXxdoCc" target="_blank">Error detection</a>
+        - <a href="https://www.youtube.com/watch?v=JAMLuxdHH8o" target="_blank">Error correction</a>
+    - <a href="https://www.youtube.com/watch?v=wbH2VxzmoZk" target="_blank">Error Checking</a>
 
 - ### Entropy
     - Also see the videos below
     - Make sure to watch information theory videos first
-    - [Information Theory, Claude Shannon, Entropy, Redundancy, Data Compression & Bits (video)](https://youtu.be/JnJq3Py0dyM?t=176)
+    - <a href="https://youtu.be/JnJq3Py0dyM?t=176" target="_blank">Information Theory, Claude Shannon, Entropy, Redundancy, Data Compression & Bits (video)</a>
 
 - ### Cryptography
     - Also see the videos below
     - Make sure to watch information theory videos first
-    - [Khan Academy Series](https://www.khanacademy.org/computing/computer-science/cryptography)
-    - [Cryptography: Hash Functions](https://www.youtube.com/watch?v=KqqOXndnvic&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=30)
-    - [Cryptography: Encryption](https://www.youtube.com/watch?v=9TNI2wHmaeI&index=31&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp)
+    - <a href="https://www.khanacademy.org/computing/computer-science/cryptography" target="_blank">Khan Academy Series</a>
+    - <a href="https://www.youtube.com/watch?v=KqqOXndnvic&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=30" target="_blank">Cryptography: Hash Functions</a>
+    - <a href="https://www.youtube.com/watch?v=9TNI2wHmaeI&index=31&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp" target="_blank">Cryptography: Encryption</a>
 
 - ### Compression
     - Make sure to watch information theory videos first
     - Computerphile (videos):
-        - [Compression](https://www.youtube.com/watch?v=Lto-ajuqW3w)
-        - [Entropy in Compression](https://www.youtube.com/watch?v=M5c_RFKVkko)
-        - [Upside Down Trees (Huffman Trees)](https://www.youtube.com/watch?v=umTbivyJoiI)
-        - [EXTRA BITS/TRITS - Huffman Trees](https://www.youtube.com/watch?v=DV8efuB3h2g)
-        - [Elegant Compression in Text (The LZ 77 Method)](https://www.youtube.com/watch?v=goOa3DGezUA)
-        - [Text Compression Meets Probabilities](https://www.youtube.com/watch?v=cCDCfoHTsaU)
-    - [Compressor Head videos](https://www.youtube.com/playlist?list=PLOU2XLYxmsIJGErt5rrCqaSGTMyyqNt2H)
-    - [(optional) Google Developers Live: GZIP is not enough!](https://www.youtube.com/watch?v=whGwm0Lky2s)
+        - <a href="https://www.youtube.com/watch?v=Lto-ajuqW3w" target="_blank">Compression</a>
+        - <a href="https://www.youtube.com/watch?v=M5c_RFKVkko" target="_blank">Entropy in Compression</a>
+        - <a href="https://www.youtube.com/watch?v=umTbivyJoiI" target="_blank">Upside Down Trees (Huffman Trees)</a>
+        - <a href="https://www.youtube.com/watch?v=DV8efuB3h2g" target="_blank">EXTRA BITS/TRITS - Huffman Trees</a>
+        - <a href="https://www.youtube.com/watch?v=goOa3DGezUA" target="_blank">Elegant Compression in Text (The LZ 77 Method)</a>
+        - <a href="https://www.youtube.com/watch?v=cCDCfoHTsaU" target="_blank">Text Compression Meets Probabilities</a>
+    - <a href="https://www.youtube.com/playlist?list=PLOU2XLYxmsIJGErt5rrCqaSGTMyyqNt2H" target="_blank">Compressor Head videos</a>
+    - <a href="https://www.youtube.com/watch?v=whGwm0Lky2s" target="_blank">(optional) Google Developers Live: GZIP is not enough!</a>
 
 - ### Computer Security
-    - [MIT (23 videos)](https://www.youtube.com/playlist?list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Introduction, Threat Models](https://www.youtube.com/watch?v=GqmQg-cszw4&index=1&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Control Hijacking Attacks](https://www.youtube.com/watch?v=6bwzNg5qQ0o&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh&index=2)
-        - [Buffer Overflow Exploits and Defenses](https://www.youtube.com/watch?v=drQyrzRoRiA&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh&index=3)
-        - [Privilege Separation](https://www.youtube.com/watch?v=6SIJmoE9L9g&index=4&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Capabilities](https://www.youtube.com/watch?v=8VqTSY-11F4&index=5&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Sandboxing Native Code](https://www.youtube.com/watch?v=VEV74hwASeU&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh&index=6)
-        - [Web Security Model](https://www.youtube.com/watch?v=chkFBigodIw&index=7&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Securing Web Applications](https://www.youtube.com/watch?v=EBQIGy1ROLY&index=8&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Symbolic Execution](https://www.youtube.com/watch?v=yRVZPvHYHzw&index=9&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Network Security](https://www.youtube.com/watch?v=SIEVvk3NVuk&index=11&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Network Protocols](https://www.youtube.com/watch?v=QOtA76ga_fY&index=12&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-        - [Side-Channel Attacks](https://www.youtube.com/watch?v=PuVMkSEcPiI&index=15&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
+    - <a href="https://www.youtube.com/playlist?list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">MIT (23 videos)</a>
+        - <a href="https://www.youtube.com/watch?v=GqmQg-cszw4&index=1&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Introduction, Threat Models</a>
+        - <a href="https://www.youtube.com/watch?v=6bwzNg5qQ0o&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh&index=2" target="_blank">Control Hijacking Attacks</a>
+        - <a href="https://www.youtube.com/watch?v=drQyrzRoRiA&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh&index=3" target="_blank">Buffer Overflow Exploits and Defenses</a>
+        - <a href="https://www.youtube.com/watch?v=6SIJmoE9L9g&index=4&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Privilege Separation</a>
+        - <a href="https://www.youtube.com/watch?v=8VqTSY-11F4&index=5&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Capabilities</a>
+        - <a href="https://www.youtube.com/watch?v=VEV74hwASeU&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh&index=6" target="_blank">Sandboxing Native Code</a>
+        - <a href="https://www.youtube.com/watch?v=chkFBigodIw&index=7&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Web Security Model</a>
+        - <a href="https://www.youtube.com/watch?v=EBQIGy1ROLY&index=8&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Securing Web Applications</a>
+        - <a href="https://www.youtube.com/watch?v=yRVZPvHYHzw&index=9&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Symbolic Execution</a>
+        - <a href="https://www.youtube.com/watch?v=SIEVvk3NVuk&index=11&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Network Security</a>
+        - <a href="https://www.youtube.com/watch?v=QOtA76ga_fY&index=12&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Network Protocols</a>
+        - <a href="https://www.youtube.com/watch?v=PuVMkSEcPiI&index=15&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">Side-Channel Attacks</a>
 
 - ### Garbage collection
-    - [GC in Python (video)](https://www.youtube.com/watch?v=iHVs_HkjdmI)
-    - [Deep Dive Java: Garbage Collection is Good!](https://www.infoq.com/presentations/garbage-collection-benefits)
-    - [Deep Dive Python: Garbage Collection in CPython (video)](https://www.youtube.com/watch?v=P-8Z0-MhdQs&list=PLdzf4Clw0VbOEWOS_sLhT_9zaiQDrS5AR&index=3)
+    - <a href="https://www.youtube.com/watch?v=iHVs_HkjdmI" target="_blank">GC in Python (video)</a>
+    - <a href="https://www.infoq.com/presentations/garbage-collection-benefits" target="_blank">Deep Dive Java: Garbage Collection is Good!</a>
+    - <a href="https://www.youtube.com/watch?v=P-8Z0-MhdQs&list=PLdzf4Clw0VbOEWOS_sLhT_9zaiQDrS5AR&index=3" target="_blank">Deep Dive Python: Garbage Collection in CPython (video)</a>
 
 - ### Parallel Programming
-    - [Coursera (Scala)](https://www.coursera.org/learn/parprog1/home/week/1)
-    - [Efficient Python for High-Performance Parallel Computing (video)](https://www.youtube.com/watch?v=uY85GkaYzBk)
+    - <a href="https://www.coursera.org/learn/parprog1/home/week/1" target="_blank">Coursera (Scala)</a>
+    - <a href="https://www.youtube.com/watch?v=uY85GkaYzBk" target="_blank">Efficient Python for High-Performance Parallel Computing (video)</a>
 
 - ### Messaging, Serialization, and Queueing Systems
-    - [Thrift](https://thrift.apache.org/)
-        - [Tutorial](http://thrift-tutorial.readthedocs.io/en/latest/intro.html)
-    - [Protocol Buffers](https://developers.google.com/protocol-buffers/)
-        - [Tutorials](https://developers.google.com/protocol-buffers/docs/tutorials)
-    - [gRPC](http://www.grpc.io/)
-        - [gRPC 101 for Java Developers (video)](https://www.youtube.com/watch?v=5tmPvSe7xXQ&list=PLcTqM9n_dieN0k1nSeN36Z_ppKnvMJoly&index=1)
-    - [Redis](http://redis.io/)
-        - [Tutorial](http://try.redis.io/)
-    - [Amazon SQS (queue)](https://aws.amazon.com/sqs/)
-    - [Amazon SNS (pub-sub)](https://aws.amazon.com/sns/)
-    - [RabbitMQ](https://www.rabbitmq.com/)
-        - [Get Started](https://www.rabbitmq.com/getstarted.html)
-    - [Celery](http://www.celeryproject.org/)
-        - [First Steps With Celery](http://docs.celeryproject.org/en/latest/getting-started/first-steps-with-celery.html)
-    - [ZeroMQ](http://zeromq.org/)
-        - [Intro - Read The Manual](http://zeromq.org/intro:read-the-manual)
-    - [ActiveMQ](http://activemq.apache.org/)
-    - [Kafka](http://kafka.apache.org/documentation.html#introduction)
-    - [MessagePack](http://msgpack.org/index.html)
-    - [Avro](https://avro.apache.org/)
+    - <a href="http://thrift.apache.org/" target="_blank">Thrift</a>
+        - <a href="http://thrift-tutorial.readthedocs.io/en/latest/intro.html" target="_blank">Tutorial</a>
+    - <a href="https://developers.google.com/protocol-buffers/" target="_blank">Protocol Buffers</a>
+        - <a href="https://developers.google.com/protocol-buffers/docs/tutorials" target="_blank">Tutorials</a>
+    - <a href="http://www.grpc.io/" target="_blank">gRPC</a>
+        - <a href="https://www.youtube.com/watch?v=5tmPvSe7xXQ&list=PLcTqM9n_dieN0k1nSeN36Z_ppKnvMJoly&index=1" target="_blank">gRPC 101 for Java Developers (video)</a>
+    - <a href="http://redis.io/" target="_blank">Redis</a>
+        - <a href="http://try.redis.io/" target="_blank">Tutorial</a>
+    - <a href="https://aws.amazon.com/sqs/" target="_blank">Amazon SQS (queue)</a>
+    - <a href="https://aws.amazon.com/sns/" target="_blank">Amazon SNS (pub-sub)</a>
+    - <a href="https://www.rabbitmq.com/" target="_blank">RabbitMQ</a>
+        - <a href="https://www.rabbitmq.com/getstarted.html" target="_blank">Get Started</a>
+    - <a href="http://www.celeryproject.org/" target="_blank">Celery</a>
+        - <a href="http://docs.celeryproject.org/en/latest/getting-started/first-steps-with-celery.html" target="_blank">First Steps With Celery</a>
+    - <a href="http://zeromq.org/" target="_blank">ZeroMQ</a>
+        - <a href="http://zeromq.org/intro:read-the-manual" target="_blank">Intro - Read The Manual</a>
+    - <a href="http://activemq.apache.org/" target="_blank">ActiveMQ</a>
+    - <a href="http://kafka.apache.org/documentation.html#introduction" target="_blank">Kafka</a>
+    - <a href="http://msgpack.org/index.html" target="_blank">MessagePack</a>
+    - <a href="https://avro.apache.org/" target="_blank">Avro</a>
 
 - ### A*
-    - [A Search Algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm)
-    - [A* Pathfinding (E01: algorithm explanation) (video)](https://www.youtube.com/watch?v=-L-WgKMFuhE)
+    - <a href="https://en.wikipedia.org/wiki/A*_search_algorithm" target="_blank">A Search Algorithm</a>
+    - <a href="https://www.youtube.com/watch?v=-L-WgKMFuhE" target="_blank">A* Pathfinding (E01: algorithm explanation) (video)</a>
 
 - ### Fast Fourier Transform
-    - [An Interactive Guide To The Fourier Transform](https://betterexplained.com/articles/an-interactive-guide-to-the-fourier-transform/)
-    - [What is a Fourier transform? What is it used for?](http://www.askamathematician.com/2012/09/q-what-is-a-fourier-transform-what-is-it-used-for/)
-    - [What is the Fourier Transform? (video)](https://www.youtube.com/watch?v=Xxut2PN-V8Q)
-    - [Divide & Conquer: FFT (video)](https://www.youtube.com/watch?v=iTMn0Kt18tg&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=4)
-    - [Understanding The FFT](http://jakevdp.github.io/blog/2013/08/28/understanding-the-fft/)
+    - <a href="https://betterexplained.com/articles/an-interactive-guide-to-the-fourier-transform/" target="_blank">An Interactive Guide To The Fourier Transform</a>
+    - <a href="http://www.askamathematician.com/2012/09/q-what-is-a-fourier-transform-what-is-it-used-for/" target="_blank">What is a Fourier transform? What is it used for?</a>
+    - <a href="https://www.youtube.com/watch?v=Xxut2PN-V8Q" target="_blank">What is the Fourier Transform? (video)</a>
+    - <a href="https://www.youtube.com/watch?v=iTMn0Kt18tg&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=4" target="_blank">Divide & Conquer: FFT (video)</a>
+    - <a href="http://jakevdp.github.io/blog/2013/08/28/understanding-the-fft/" target="_blank">Understanding The FFT</a>
 
 - ### Bloom Filter
     - Given a Bloom filter with m bits and k hashing functions, both insertion and membership testing are O(k)
-    - [Bloom Filters (video)](https://www.youtube.com/watch?v=-SuTGoFYjZs)
-    - [Bloom Filters | Mining of Massive Datasets | Stanford University (video)](https://www.youtube.com/watch?v=qBTdukbzc78)
-    - [Tutorial](http://billmill.org/bloomfilter-tutorial/)
-    - [How To Write A Bloom Filter App](http://blog.michaelschmatz.com/2016/04/11/how-to-write-a-bloom-filter-cpp/)
+    - <a href="https://www.youtube.com/watch?v=-SuTGoFYjZs" target="_blank">Bloom Filters (video)</a>
+    - <a href="https://www.youtube.com/watch?v=qBTdukbzc78" target="_blank">Bloom Filters | Mining of Massive Datasets | Stanford University (video)</a>
+    - <a href="http://billmill.org/bloomfilter-tutorial/" target="_blank">Tutorial</a>
+    - <a href="http://blog.michaelschmatz.com/2016/04/11/how-to-write-a-bloom-filter-cpp/" target="_blank">How To Write A Bloom Filter App</a>
 
 - ### HyperLogLog
-    - [How To Count A Billion Distinct Objects Using Only 1.5KB Of Memory](http://highscalability.com/blog/2012/4/5/big-data-counting-how-to-count-a-billion-distinct-objects-us.html)
+    - <a href="http://highscalability.com/blog/2012/4/5/big-data-counting-how-to-count-a-billion-distinct-objects-us.html" target="_blank">How To Count A Billion Distinct Objects Using Only 1.5KB Of Memory</a>
 
 - ### Locality-Sensitive Hashing
     - Used to determine the similarity of documents
     - The opposite of MD5 or SHA which are used to determine if 2 documents/strings are exactly the same
-    - [Simhashing (hopefully) made simple](http://ferd.ca/simhashing-hopefully-made-simple.html)
+    - <a href="http://ferd.ca/simhashing-hopefully-made-simple.html" target="_blank">Simhashing (hopefully) made simple</a>
 
 - ### van Emde Boas Trees
-    - [Divide & Conquer: van Emde Boas Trees (video)](https://www.youtube.com/watch?v=hmReJCupbNU&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=6)
-    - [MIT Lecture Notes](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-046j-design-and-analysis-of-algorithms-spring-2012/lecture-notes/MIT6_046JS12_lec15.pdf)
+    - <a href="https://www.youtube.com/watch?v=hmReJCupbNU&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=6" target="_blank">Divide & Conquer: van Emde Boas Trees (video)</a>
+    - <a href="https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-046j-design-and-analysis-of-algorithms-spring-2012/lecture-notes/MIT6_046JS12_lec15.pdf" target="_blank">MIT Lecture Notes</a>
 
 - ### Augmented Data Structures
-    - [CS 61B Lecture 39: Augmenting Data Structures](https://archive.org/details/ucberkeley_webcast_zksIj9O8_jc)
+    - <a href="https://archive.org/details/ucberkeley_webcast_zksIj9O8_jc" target="_blank">CS 61B Lecture 39: Augmenting Data Structures</a>
 
 - ### Balanced search trees
     - Know at least one type of balanced binary tree (and know how it's implemented):
@@ -1699,7 +1700,7 @@ You're never really done.
         If you end up implementing a red/black tree try just these:
         - Search and insertion functions, skipping delete
     - I want to learn more about B-Tree since it's used so widely with very large data sets
-    - [Self-balancing binary search tree](https://en.wikipedia.org/wiki/Self-balancing_binary_search_tree)
+    - <a href="https://en.wikipedia.org/wiki/Self-balancing_binary_search_tree" target="_blank">Self-balancing binary search tree</a>
 
     - **AVL trees**
         - In practice:
@@ -1708,21 +1709,21 @@ You're never really done.
             balanced than red–black trees, leading to slower insertion and removal but faster retrieval. This makes it
             attractive for data structures that may be built once and loaded without reconstruction, such as language
             dictionaries (or program dictionaries, such as the opcodes of an assembler or interpreter)
-        - [MIT AVL Trees / AVL Sort (video)](https://www.youtube.com/watch?v=FNeL18KsWPc&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=6)
-        - [AVL Trees (video)](https://www.coursera.org/learn/data-structures/lecture/Qq5E0/avl-trees)
-        - [AVL Tree Implementation (video)](https://www.coursera.org/learn/data-structures/lecture/PKEBC/avl-tree-implementation)
-        - [Split And Merge](https://www.coursera.org/learn/data-structures/lecture/22BgE/split-and-merge)
-        - [[Review] AVL Trees (playlist) in 19 minutes (video)](https://www.youtube.com/playlist?list=PL9xmBV_5YoZOUFgdIeOPuH6cfSnNRMau-)
+        - <a href="https://www.youtube.com/watch?v=FNeL18KsWPc&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=6" target="_blank">MIT AVL Trees / AVL Sort (video)</a>
+        - <a href="https://www.coursera.org/learn/data-structures/lecture/Qq5E0/avl-trees" target="_blank">AVL Trees (video)</a>
+        - <a href="https://www.coursera.org/learn/data-structures/lecture/PKEBC/avl-tree-implementation" target="_blank">AVL Tree Implementation (video)</a>
+        - <a href="https://www.coursera.org/learn/data-structures/lecture/22BgE/split-and-merge" target="_blank">Split And Merge</a>
+        - <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZOUFgdIeOPuH6cfSnNRMau-" target="_blank">[Review] AVL Trees (playlist) in 19 minutes (video)</a>
 
     - **Splay trees**
         - In practice:
             Splay trees are typically used in the implementation of caches, memory allocators, routers, garbage collectors,
             data compression, ropes (replacement of string used for long text strings), in Windows NT (in the virtual memory,
             networking and file system code) etc
-        - [CS 61B: Splay Trees (video)](https://archive.org/details/ucberkeley_webcast_G5QIXywcJlY)
+        - <a href="https://archive.org/details/ucberkeley_webcast_G5QIXywcJlY" target="_blank">CS 61B: Splay Trees (video)</a>
         - MIT Lecture: Splay Trees:
             - Gets very mathy, but watch the last 10 minutes for sure.
-            - [Video](https://www.youtube.com/watch?v=QnPl_Y6EqMo)
+            - <a href="https://www.youtube.com/watch?v=QnPl_Y6EqMo" target="_blank">Video</a>
 
     - **Red/black trees**
         - These are a translation of a 2-3 tree (see below).
@@ -1734,19 +1735,19 @@ You're never really done.
             the Completely Fair Scheduler used in current Linux kernels uses red–black trees. In version 8 of Java,
             the Collection HashMap has been modified such that instead of using a LinkedList to store identical elements with poor
             hashcodes, a Red-Black tree is used
-        - [Aduni - Algorithms - Lecture 4 (link jumps to the starting point) (video)](https://youtu.be/1W3x0f_RmUo?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=3871)
-        - [Aduni - Algorithms - Lecture 5 (video)](https://www.youtube.com/watch?v=hm2GHwyKF1o&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=5)
-        - [Red-Black Tree](https://en.wikipedia.org/wiki/Red%E2%80%93black_tree)
-        - [An Introduction To Binary Search And Red Black Tree](https://www.topcoder.com/thrive/articles/An%20Introduction%20to%20Binary%20Search%20and%20Red-Black%20Trees)
-        - [[Review] Red-Black Trees (playlist) in 30 minutes (video)](https://www.youtube.com/playlist?list=PL9xmBV_5YoZNqDI8qfOZgzbqahCUmUEin)
+        - <a href="https://youtu.be/1W3x0f_RmUo?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=3871" target="_blank">Aduni - Algorithms - Lecture 4 (link jumps to the starting point) (video)</a>
+        - <a href="https://www.youtube.com/watch?v=hm2GHwyKF1o&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=5" target="_blank">Aduni - Algorithms - Lecture 5 (video)</a>
+        - <a href="https://en.wikipedia.org/wiki/Red%E2%80%93black_tree" target="_blank">Red-Black Tree</a>
+        - <a href="https://www.topcoder.com/thrive/articles/An%20Introduction%20to%20Binary%20Search%20and%20Red-Black%20Trees" target="_blank">An Introduction To Binary Search And Red Black Tree</a>
+        - <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZNqDI8qfOZgzbqahCUmUEin" target="_blank">[Review] Red-Black Trees (playlist) in 30 minutes (video)</a>
 
-    - **2-3 search trees**
+   - **2-3 search trees**
         - In practice:
             2-3 trees have faster inserts at the expense of slower searches (since height is more compared to AVL trees).
         - You would use 2-3 trees very rarely because its implementation involves different types of nodes. Instead, people use Red-Black trees.
-        - [23-Tree Intuition and Definition (video)](https://www.youtube.com/watch?v=C3SsdUqasD4&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6&index=2)
-        - [Binary View of 23-Tree](https://www.youtube.com/watch?v=iYvBtGKsqSg&index=3&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6)
-        - [2-3 Trees (student recitation) (video)](https://www.youtube.com/watch?v=TOb1tuEZ2X4&index=5&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp)
+        - <a href="https://www.youtube.com/watch?v=C3SsdUqasD4&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6&index=2" target="_blank">23-Tree Intuition and Definition (video)</a>
+        - <a href="https://www.youtube.com/watch?v=iYvBtGKsqSg&index=3&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6" target="_blank">Binary View of 23-Tree</a>
+        - <a href="https://www.youtube.com/watch?v=TOb1tuEZ2X4&index=5&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp" target="_blank">2-3 Trees (student recitation) (video)</a>
 
     - **2-3-4 Trees (aka 2-4 trees)**
         - In practice:
@@ -1754,15 +1755,15 @@ You're never really done.
             operations on 2-4 trees are also equivalent to color-flipping and rotations in red–black trees. This makes 2-4 trees an
             important tool for understanding the logic behind red-black trees, and this is why many introductory algorithm texts introduce
             2-4 trees just before red–black trees, even though **2-4 trees are not often used in practice**.
-        - [CS 61B Lecture 26: Balanced Search Trees (video)](https://archive.org/details/ucberkeley_webcast_zqrqYXkth6Q)
-        - [Bottom Up 234-Trees (video)](https://www.youtube.com/watch?v=DQdMYevEyE4&index=4&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6)
-        - [Top Down 234-Trees (video)](https://www.youtube.com/watch?v=2679VQ26Fp4&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6&index=5)
+        - <a href="https://archive.org/details/ucberkeley_webcast_zqrqYXkth6Q" target="_blank">CS 61B Lecture 26: Balanced Search Trees (video)</a>
+        - <a href="https://www.youtube.com/watch?v=DQdMYevEyE4&index=4&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6" target="_blank">Bottom Up 234-Trees (video)</a>
+        - <a href="https://www.youtube.com/watch?v=2679VQ26Fp4&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6&index=5" target="_blank">Top Down 234-Trees (video)</a>
 
     - **N-ary (K-ary, M-ary) trees**
         - note: the N or K is the branching factor (max branches)
         - binary trees are a 2-ary tree, with branching factor = 2
         - 2-3 trees are 3-ary
-        - [K-Ary Tree](https://en.wikipedia.org/wiki/K-ary_tree)
+        - <a href="https://en.wikipedia.org/wiki/K-ary_tree" target="_blank">K-Ary Tree</a>
 
     - **B-Trees**
         - Fun fact: it's a mystery, but the B could stand for Boeing, Balanced, or Bayer (co-inventor).
@@ -1771,61 +1772,60 @@ You're never really done.
             its use in databases, the B-tree is also used in filesystems to allow quick random access to an arbitrary
             block in a particular file. The basic problem is turning the file block address into a disk block
             (or perhaps to a cylinder head sector) address
-        - [B-Tree](https://en.wikipedia.org/wiki/B-tree)
-        - [B-Tree Datastructure](http://btechsmartclass.com/data_structures/b-trees.html)
-        - [Introduction to B-Trees (video)](https://www.youtube.com/watch?v=I22wEC1tTGo&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6&index=6)
-        - [B-Tree Definition and Insertion (video)](https://www.youtube.com/watch?v=s3bCdZGrgpA&index=7&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6)
-        - [B-Tree Deletion (video)](https://www.youtube.com/watch?v=svfnVhJOfMc&index=8&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6)
-        - [MIT 6.851 - Memory Hierarchy Models (video)](https://www.youtube.com/watch?v=V3omVLzI0WE&index=7&list=PLUl4u3cNGP61hsJNdULdudlRL493b-XZf)
+        - <a href="https://en.wikipedia.org/wiki/B-tree" target="_blank">B-Tree</a>
+        - <a href="http://btechsmartclass.com/data_structures/b-trees.html" target="_blank">B-Tree Datastructure</a>
+        - <a href="https://www.youtube.com/watch?v=I22wEC1tTGo&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6&index=6" target="_blank">Introduction to B-Trees (video)</a>
+        - <a href="https://www.youtube.com/watch?v=s3bCdZGrgpA&index=7&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6" target="_blank">B-Tree Definition and Insertion (video)</a>
+        - <a href="https://www.youtube.com/watch?v=svfnVhJOfMc&index=8&list=PLA5Lqm4uh9Bbq-E0ZnqTIa8LRaL77ica6" target="_blank">B-Tree Deletion (video)</a>
+        - <a href="https://www.youtube.com/watch?v=V3omVLzI0WE&index=7&list=PLUl4u3cNGP61hsJNdULdudlRL493b-XZf" target="_blank">MIT 6.851 - Memory Hierarchy Models (video)</a>
                 - covers cache-oblivious B-Trees, very interesting data structures
                 - the first 37 minutes are very technical, and may be skipped (B is block size, cache line size)
-        - [[Review] B-Trees (playlist) in 26 minutes (video)](https://www.youtube.com/playlist?list=PL9xmBV_5YoZNFPPv98DjTdD9X6UI9KMHz)
-
+        - <a href="https://www.youtube.com/playlist?list=PL9xmBV_5YoZNFPPv98DjTdD9X6UI9KMHz" target="_blank">[Review] B-Trees (playlist) in 26 minutes (video)</a>
 
 - ### k-D Trees
     - Great for finding a number of points in a rectangle or higher-dimensional object
     - A good fit for k-nearest neighbors
-    - [kNN K-d tree algorithm (video)](https://www.youtube.com/watch?v=Y4ZgLlDfKDg)
+    - <a href="https://www.youtube.com/watch?v=Y4ZgLlDfKDg" target="_blank">kNN K-d tree algorithm (video)</a>
 
 - ### Skip lists
     - "These are somewhat of a cult data structure" - Skiena
-    - [Randomization: Skip Lists (video)](https://www.youtube.com/watch?v=2g9OSRKJuzM&index=10&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp)
-    - [For animations and a little more detail](https://en.wikipedia.org/wiki/Skip_list)
+    - <a href="https://www.youtube.com/watch?v=2g9OSRKJuzM&index=10&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp" target="_blank">Randomization: Skip Lists (video)</a>
+    - <a href="https://en.wikipedia.org/wiki/Skip_list" target="_blank">For animations and a little more detail</a>
 
 - ### Network Flows
-    - [Ford-Fulkerson in 5 minutes — Step by step example (video)](https://www.youtube.com/watch?v=Tl90tNtKvxs)
-    - [Ford-Fulkerson Algorithm (video)](https://www.youtube.com/watch?v=v1VgJmkEJW0)
-    - [Network Flows (video)](https://www.youtube.com/watch?v=2vhN4Ice5jI)
+    - <a href="https://www.youtube.com/watch?v=Tl90tNtKvxs" target="_blank">Ford-Fulkerson in 5 minutes — Step by step example (video)</a>
+    - <a href="https://www.youtube.com/watch?v=v1VgJmkEJW0" target="_blank">Ford-Fulkerson Algorithm (video)</a>
+    - <a href="https://www.youtube.com/watch?v=2vhN4Ice5jI" target="_blank">Network Flows (video)</a>
 
 - ### Disjoint Sets & Union Find
-    - [UCB 61B - Disjoint Sets; Sorting & selection (video)](https://archive.org/details/ucberkeley_webcast_MAEGXTwmUsI)
-    - [Sedgewick Algorithms - Union-Find (6 videos)](https://www.coursera.org/learn/algorithms-part1/home/week/1)
+    - <a href="https://archive.org/details/ucberkeley_webcast_MAEGXTwmUsI" target="_blank">UCB 61B - Disjoint Sets; Sorting & selection (video)</a>
+    - <a href="https://www.coursera.org/learn/algorithms-part1/home/week/1" target="_blank">Sedgewick Algorithms - Union-Find (6 videos)</a>
 
 - ### Math for Fast Processing
-    - [Integer Arithmetic, Karatsuba Multiplication (video)](https://www.youtube.com/watch?v=eCaXlAaN2uE&index=11&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb)
-    - [The Chinese Remainder Theorem (used in cryptography) (video)](https://www.youtube.com/watch?v=ru7mWZJlRQg)
+    - <a href="https://www.youtube.com/watch?v=eCaXlAaN2uE&index=11&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb" target="_blank">Integer Arithmetic, Karatsuba Multiplication (video)</a>
+    - <a href="https://www.youtube.com/watch?v=ru7mWZJlRQg" target="_blank">The Chinese Remainder Theorem (used in cryptography) (video)</a>
 
 - ### Treap
     - Combination of a binary search tree and a heap
-    - [Treap](https://en.wikipedia.org/wiki/Treap)
-    - [Data Structures: Treaps explained (video)](https://www.youtube.com/watch?v=6podLUYinH8)
-    - [Applications in set operations](https://www.cs.cmu.edu/~scandal/papers/treaps-spaa98.pdf)
+    - <a href="https://en.wikipedia.org/wiki/Treap" target="_blank">Treap</a>
+    - <a href="https://www.youtube.com/watch?v=6podLUYinH8" target="_blank">Data Structures: Treaps explained (video)</a>
+    - <a href="https://www.cs.cmu.edu/~scandal/papers/treaps-spaa98.pdf" target="_blank">Applications in set operations</a>
 
 - ### Linear Programming (videos)
-    - [Linear Programming](https://www.youtube.com/watch?v=M4K6HYLHREQ)
-    - [Finding minimum cost](https://www.youtube.com/watch?v=2ACJ9ewUC6U)
-    - [Finding maximum value](https://www.youtube.com/watch?v=8AA_81xI3ik)
-    - [Solve Linear Equations with Python - Simplex Algorithm](https://www.youtube.com/watch?v=44pAWI7v5Zk)
+    - <a href="https://www.youtube.com/watch?v=M4K6HYLHREQ" target="_blank">Linear Programming</a>
+    - <a href="https://www.youtube.com/watch?v=2ACJ9ewUC6U" target="_blank">Finding minimum cost</a>
+    - <a href="https://www.youtube.com/watch?v=8AA_81xI3ik" target="_blank">Finding maximum value</a>
+    - <a href="https://www.youtube.com/watch?v=44pAWI7v5Zk" target="_blank">Solve Linear Equations with Python - Simplex Algorithm</a>
 
 - ### Geometry, Convex hull (videos)
-    - [Graph Alg. IV: Intro to geometric algorithms - Lecture 9](https://youtu.be/XIAQRlNkJAw?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=3164)
-    - [Geometric Algorithms: Graham & Jarvis - Lecture 10](https://www.youtube.com/watch?v=J5aJEcOr6Eo&index=10&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm)
-    - [Divide & Conquer: Convex Hull, Median Finding](https://www.youtube.com/watch?v=EzeYI7p9MjU&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=2)
+    - <a href="https://youtu.be/XIAQRlNkJAw?list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&t=3164" target="_blank">Graph Alg. IV: Intro to geometric algorithms - Lecture 9</a>
+    - <a href="https://www.youtube.com/watch?v=J5aJEcOr6Eo&index=10&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm" target="_blank">Geometric Algorithms: Graham & Jarvis - Lecture 10</a>
+    - <a href="https://www.youtube.com/watch?v=EzeYI7p9MjU&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=2" target="_blank">Divide & Conquer: Convex Hull, Median Finding</a>
 
 - ### Discrete math
-    - [Computer Science 70, 001 - Spring 2015 - Discrete Mathematics and Probability Theory](http://www.infocobuild.com/education/audio-video-courses/computer-science/cs70-spring2015-berkeley.html)
-    - [Discrete Mathematics by Shai Simonson (19 videos)](https://www.youtube.com/playlist?list=PLWX710qNZo_sNlSWRMVIh6kfTjolNaZ8t)
-    - [Discrete Mathematics By IIT Ropar NPTEL](https://nptel.ac.in/courses/106/106/106106183/)
+    - <a href="http://www.infocobuild.com/education/audio-video-courses/computer-science/cs70-spring2015-berkeley.html" target="_blank">Computer Science 70, 001 - Spring 2015 - Discrete Mathematics and Probability Theory</a>
+    - <a href="https://www.youtube.com/playlist?list=PLWX710qNZo_sNlSWRMVIh6kfTjolNaZ8t" target="_blank">Discrete Mathematics by Shai Simonson (19 videos)</a>
+    - <a href="https://nptel.ac.in/courses/106/106/106106183/" target="_blank">Discrete Mathematics By IIT Ropar NPTEL</a>
 
 ---
 
@@ -1837,182 +1837,157 @@ You're never really done.
     above because it's just too much. It's easy to overdo it on a subject.
     You want to get hired in this century, right?
 
-- **SOLID**
-    - [ ] [Bob Martin SOLID Principles of Object Oriented and Agile Design (video)](https://www.youtube.com/watch?v=TMuno5RZNeE)
-    - [ ] S - [Single Responsibility Principle](http://www.oodesign.com/single-responsibility-principle.html) | [Single responsibility to each Object](http://www.javacodegeeks.com/2011/11/solid-single-responsibility-principle.html)
-        - [more flavor](https://docs.google.com/open?id=0ByOwmqah_nuGNHEtcU5OekdDMkk)
-    - [ ] O - [Open/Closed Principle](http://www.oodesign.com/open-close-principle.html)  | [On production level Objects are ready for extension but not for modification](https://en.wikipedia.org/wiki/Open/closed_principle)
-        - [more flavor](http://docs.google.com/a/cleancoder.com/viewer?a=v&pid=explorer&chrome=true&srcid=0BwhCYaYDn8EgN2M5MTkwM2EtNWFkZC00ZTI3LWFjZTUtNTFhZGZiYmUzODc1&hl=en)
-    - [ ] L - [Liskov Substitution Principle](http://www.oodesign.com/liskov-s-substitution-principle.html) | [Base Class and Derived class follow ‘IS A’ Principle](http://stackoverflow.com/questions/56860/what-is-the-liskov-substitution-principle)
-        - [more flavor](http://docs.google.com/a/cleancoder.com/viewer?a=v&pid=explorer&chrome=true&srcid=0BwhCYaYDn8EgNzAzZjA5ZmItNjU3NS00MzQ5LTkwYjMtMDJhNDU5ZTM0MTlh&hl=en)
-    - [ ] I - [Interface segregation principle](http://www.oodesign.com/interface-segregation-principle.html) | Clients should not be forced to implement interfaces they don't use
-        - [Interface Segregation Principle in 5 minutes (video)](https://www.youtube.com/watch?v=3CtAfl7aXAQ)
-        - [more flavor](http://docs.google.com/a/cleancoder.com/viewer?a=v&pid=explorer&chrome=true&srcid=0BwhCYaYDn8EgOTViYjJhYzMtMzYxMC00MzFjLWJjMzYtOGJiMDc5N2JkYmJi&hl=en)
-    - [ ] D -[Dependency Inversion principle](http://www.oodesign.com/dependency-inversion-principle.html) | Reduce the dependency In composition of objects.
-        - [Why Is The Dependency Inversion Principle And Why Is It Important](http://stackoverflow.com/questions/62539/what-is-the-dependency-inversion-principle-and-why-is-it-important)
-        - [more flavor](http://docs.google.com/a/cleancoder.com/viewer?a=v&pid=explorer&chrome=true&srcid=0BwhCYaYDn8EgMjdlMWIzNGUtZTQ0NC00ZjQ5LTkwYzQtZjRhMDRlNTQ3ZGMz&hl=en)
+- <b>SOLID</b>
+    - [ ] <a href="https://www.youtube.com/watch?v=TMuno5RZNeE" target="_blank">Bob Martin SOLID Principles of Object Oriented and Agile Design (video)</a>
+    - [ ] S - <a href="http://www.oodesign.com/single-responsibility-principle.html" target="_blank">Single Responsibility Principle</a> | <a href="http://www.javacodegeeks.com/2011/11/solid-single-responsibility-principle.html" target="_blank">Single responsibility to each Object</a>
+        - <a href="https://docs.google.com/open?id=0ByOwmqah_nuGNHEtcU5OekdDMkk" target="_blank">more flavor</a>
+    - [ ] O - <a href="http://www.oodesign.com/open-close-principle.html" target="_blank">Open/Closed Principle</a>  | <a href="https://en.wikipedia.org/wiki/Open/closed_principle" target="_blank">On production level Objects are ready for extension but not for modification</a>
+        - <a href="http://docs.google.com/a/cleancoder.com/viewer?a=v&pid=explorer&chrome=true&srcid=0BwhCYaYDn8EgN2M5MTkwM2EtNWFkZC00ZTI3LWFjZTUtNTFhZGZiYmUzODc1&hl=en" target="_blank">more flavor</a>
+    - [ ] L - <a href="http://www.oodesign.com/liskov-s-substitution-principle.html" target="_blank">Liskov Substitution Principle</a> | <a href="http://stackoverflow.com/questions/56860/what-is-the-liskov-substitution-principle" target="_blank">Base Class and Derived class follow ‘IS A’ Principle</a>
+        - <a href="http://docs.google.com/a/cleancoder.com/viewer?a=v&pid=explorer&chrome=true&srcid=0BwhCYaYDn8EgNzAzZjA5ZmItNjU3NS00MzQ5LTkwYjMtMDJhNDU5ZTM0MTlh&hl=en" target="_blank">more flavor</a>
+    - [ ] I - <a href="http://www.oodesign.com/interface-segregation-principle.html" target="_blank">Interface segregation principle</a> | Clients should not be forced to implement interfaces they don't use
+        - <a href="https://www.youtube.com/watch?v=3CtAfl7aXAQ" target="_blank">Interface Segregation Principle in 5 minutes (video)</a>
+        - <a href="http://docs.google.com/a/cleancoder.com/viewer?a=v&pid=explorer&chrome=true&srcid=0BwhCYaYDn8EgOTViYjJhYzMtMzYxMC00MzFjLWJjMzYtOGJiMDc5N2JkYmJi&hl=en" target="_blank">more flavor</a>
+    - [ ] D -<a href="http://www.oodesign.com/dependency-inversion-principle.html" target="_blank">Dependency Inversion principle</a> | Reduce the dependency In composition of objects.
+        - <a href="http://stackoverflow.com/questions/62539/what-is-the-dependency-inversion-principle-and-why-is-it-important" target="_blank">Why Is The Dependency Inversion Principle And Why Is It Important</a>
+        - <a href="http://docs.google.com/a/cleancoder.com/viewer?a=v&pid=explorer&chrome=true&srcid=0BwhCYaYDn8EgMjdlMWIzNGUtZTQ0NC00ZjQ5LTkwYzQtZjRhMDRlNTQ3ZGMz&hl=en" target="_blank">more flavor</a>
 
+- <b>Union-Find</b>
+    - <a href="https://www.coursera.org/learn/data-structures/lecture/JssSY/overview" target="_blank">Overview</a>
+    - <a href="https://www.coursera.org/learn/data-structures/lecture/EM5D0/naive-implementations" target="_blank">Naive Implementation</a>
+    - <a href="https://www.coursera.org/learn/data-structures/lecture/Mxu0w/trees" target="_blank">Trees</a>
+    - <a href="https://www.coursera.org/learn/data-structures/lecture/qb4c2/union-by-rank" target="_blank">Union By Rank</a>
+    - <a href="https://www.coursera.org/learn/data-structures/lecture/Q9CVI/path-compression" target="_blank">Path Compression</a>
+    - <a href="https://www.coursera.org/learn/data-structures/lecture/GQQLN/analysis-optional" target="_blank">Analysis Options</a>
 
-- **Union-Find**
-    - [Overview](https://www.coursera.org/learn/data-structures/lecture/JssSY/overview)
-    - [Naive Implementation](https://www.coursera.org/learn/data-structures/lecture/EM5D0/naive-implementations)
-    - [Trees](https://www.coursera.org/learn/data-structures/lecture/Mxu0w/trees)
-    - [Union By Rank](https://www.coursera.org/learn/data-structures/lecture/qb4c2/union-by-rank)
-    - [Path Compression](https://www.coursera.org/learn/data-structures/lecture/Q9CVI/path-compression)
-    - [Analysis Options](https://www.coursera.org/learn/data-structures/lecture/GQQLN/analysis-optional)
+- <b>More Dynamic Programming</b> (videos)
+    - <a href="https://www.youtube.com/watch?v=r4-cftqTcdI&ab_channel=MITOpenCourseWare" target="_blank">6.006: Dynamic Programming I: Fibonacci, Shortest Paths</a>
+    - <a href="https://www.youtube.com/watch?v=KLBCUx1is2c&ab_channel=MITOpenCourseWare" target="_blank">6.006: Dynamic Programming II: Text Justification, Blackjack</a>
+    - <a href="https://www.youtube.com/watch?v=TDo3r5M1LNo&ab_channel=MITOpenCourseWare" target="_blank">6.006: DP III: Parenthesization, Edit Distance, Knapsack</a>
+    - <a href="https://www.youtube.com/watch?v=i9OAOk0CUQE&ab_channel=MITOpenCourseWare" target="_blank">6.006: DP IV: Guitar Fingering, Tetris, Super Mario Bros.</a>
+    - <a href="https://www.youtube.com/watch?v=Tw1k46ywN6E&index=14&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp" target="_blank">6.046: Dynamic Programming & Advanced DP</a>
+    - <a href="https://www.youtube.com/watch?v=NzgFUwOaoIw&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=15" target="_blank">6.046: Dynamic Programming: All-Pairs Shortest Paths</a>
+    - <a href="https://www.youtube.com/watch?v=krZI60lKPek&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=12" target="_blank">6.046: Dynamic Programming (student recitation)</a>
 
-- **More Dynamic Programming** (videos)
-    - [6.006: Dynamic Programming I: Fibonacci, Shortest Paths](https://www.youtube.com/watch?v=r4-cftqTcdI&ab_channel=MITOpenCourseWare)
-    - [6.006: Dynamic Programming II: Text Justification, Blackjack](https://www.youtube.com/watch?v=KLBCUx1is2c&ab_channel=MITOpenCourseWare)
-    - [6.006: DP III: Parenthesization, Edit Distance, Knapsack](https://www.youtube.com/watch?v=TDo3r5M1LNo&ab_channel=MITOpenCourseWare)
-    - [6.006: DP IV: Guitar Fingering, Tetris, Super Mario Bros.](https://www.youtube.com/watch?v=i9OAOk0CUQE&ab_channel=MITOpenCourseWare)
-    - [6.046: Dynamic Programming & Advanced DP](https://www.youtube.com/watch?v=Tw1k46ywN6E&index=14&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp)
-    - [6.046: Dynamic Programming: All-Pairs Shortest Paths](https://www.youtube.com/watch?v=NzgFUwOaoIw&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=15)
-    - [6.046: Dynamic Programming (student recitation)](https://www.youtube.com/watch?v=krZI60lKPek&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=12)
+- <b>Advanced Graph Processing</b> (videos)
+    - <a href="https://www.youtube.com/watch?v=mUBmcbbJNf4&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=27" target="_blank">Synchronous Distributed Algorithms: Symmetry-Breaking. Shortest-Paths Spanning Trees</a>
+    - <a href="https://www.youtube.com/watch?v=kQ-UQAzcnzA&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=28" target="_blank">Asynchronous Distributed Algorithms: Shortest-Paths Spanning Trees</a>
 
-- **Advanced Graph Processing** (videos)
-    - [Synchronous Distributed Algorithms: Symmetry-Breaking. Shortest-Paths Spanning Trees](https://www.youtube.com/watch?v=mUBmcbbJNf4&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=27)
-    - [Asynchronous Distributed Algorithms: Shortest-Paths Spanning Trees](https://www.youtube.com/watch?v=kQ-UQAzcnzA&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp&index=28)
+- MIT <b>Probability</b> (mathy, and go slowly, which is good for mathy things) (videos):
+    - <a href="https://www.youtube.com/watch?v=SmFwFdESMHI&index=18&list=PLB7540DEDD482705B" target="_blank">MIT 6.042J - Probability Introduction</a>
+    - <a href="https://www.youtube.com/watch?v=E6FbvM-FGZ8&index=19&list=PLB7540DEDD482705B" target="_blank">MIT 6.042J - Conditional Probability</a>
+    - <a href="https://www.youtube.com/watch?v=l1BCv3qqW4A&index=20&list=PLB7540DEDD482705B" target="_blank">MIT 6.042J - Independence</a>
+    - <a href="https://www.youtube.com/watch?v=MOfhhFaQdjw&list=PLB7540DEDD482705B&index=21" target="_blank">MIT 6.042J - Random Variables</a>
+    - <a href="https://www.youtube.com/watch?v=gGlMSe7uEkA&index=22&list=PLB7540DEDD482705B" target="_blank">MIT 6.042J - Expectation I</a>
+    - <a href="https://www.youtube.com/watch?v=oI9fMUqgfxY&index=23&list=PLB7540DEDD482705B" target="_blank">MIT 6.042J - Expectation II</a>
+    - <a href="https://www.youtube.com/watch?v=q4mwO2qS2z4&index=24&list=PLB7540DEDD482705B" target="_blank">MIT 6.042J - Large Deviations</a>
+    - <a href="https://www.youtube.com/watch?v=56iFMY8QW2k&list=PLB7540DEDD482705B&index=25" target="_blank">MIT 6.042J - Random Walks</a>
 
-- MIT **Probability** (mathy, and go slowly, which is good for mathy things) (videos):
-    - [MIT 6.042J - Probability Introduction](https://www.youtube.com/watch?v=SmFwFdESMHI&index=18&list=PLB7540DEDD482705B)
-    - [MIT 6.042J - Conditional Probability](https://www.youtube.com/watch?v=E6FbvM-FGZ8&index=19&list=PLB7540DEDD482705B)
-    - [MIT 6.042J - Independence](https://www.youtube.com/watch?v=l1BCv3qqW4A&index=20&list=PLB7540DEDD482705B)
-    - [MIT 6.042J - Random Variables](https://www.youtube.com/watch?v=MOfhhFaQdjw&list=PLB7540DEDD482705B&index=21)
-    - [MIT 6.042J - Expectation I](https://www.youtube.com/watch?v=gGlMSe7uEkA&index=22&list=PLB7540DEDD482705B)
-    - [MIT 6.042J - Expectation II](https://www.youtube.com/watch?v=oI9fMUqgfxY&index=23&list=PLB7540DEDD482705B)
-    - [MIT 6.042J - Large Deviations](https://www.youtube.com/watch?v=q4mwO2qS2z4&index=24&list=PLB7540DEDD482705B)
-    - [MIT 6.042J - Random Walks](https://www.youtube.com/watch?v=56iFMY8QW2k&list=PLB7540DEDD482705B&index=25)
+- <a href="https://www.youtube.com/watch?v=oDniZCmNmNw&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=19" target="_blank">Simonson: Approximation Algorithms (video)</a>
 
-- [Simonson: Approximation Algorithms (video)](https://www.youtube.com/watch?v=oDniZCmNmNw&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=19)
-
-- **String Matching**
+- <strong>String Matching</strong>
     - Rabin-Karp (videos):
-        - [Rabin Karps Algorithm](https://www.coursera.org/lecture/data-structures/rabin-karps-algorithm-c0Qkw)
-        - [Precomputing](https://www.coursera.org/learn/data-structures/lecture/nYrc8/optimization-precomputation)
-        - [Optimization: Implementation and Analysis](https://www.coursera.org/learn/data-structures/lecture/h4ZLc/optimization-implementation-and-analysis)
-        - [Table Doubling, Karp-Rabin](https://www.youtube.com/watch?v=BRO7mVIFt08&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=9)
-        - [Rolling Hashes, Amortized Analysis](https://www.youtube.com/watch?v=w6nuXg0BISo&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=32)
+        - <a href="https://www.coursera.org/lecture/data-structures/rabin-karps-algorithm-c0Qkw" target="_blank">Rabin Karps Algorithm</a>
+        - <a href="https://www.coursera.org/learn/data-structures/lecture/nYrc8/optimization-precomputation" target="_blank">Precomputing</a>
+        - <a href="https://www.coursera.org/learn/data-structures/lecture/h4ZLc/optimization-implementation-and-analysis" target="_blank">Optimization: Implementation and Analysis</a>
+        - <a href="https://www.youtube.com/watch?v=BRO7mVIFt08&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=9" target="_blank">Table Doubling, Karp-Rabin</a>
+        - <a href="https://www.youtube.com/watch?v=w6nuXg0BISo&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&index=32" target="_blank">Rolling Hashes, Amortized Analysis</a>
     - Knuth-Morris-Pratt (KMP):
-        - [TThe Knuth-Morris-Pratt (KMP) String Matching Algorithm](https://www.youtube.com/watch?v=5i7oKodCRJo)
+        - <a href="https://www.youtube.com/watch?v=5i7oKodCRJo" target="_blank">TThe Knuth-Morris-Pratt (KMP) String Matching Algorithm</a>
     - Boyer–Moore string search algorithm
-        - [Boyer-Moore String Search Algorithm](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string_search_algorithm)
-        - [Advanced String Searching Boyer-Moore-Horspool Algorithms (video)](https://www.youtube.com/watch?v=QDZpzctPf10)
-    - [Coursera: Algorithms on Strings](https://www.coursera.org/learn/algorithms-on-strings/home/week/1)
+        - <a href="https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string_search_algorithm" target="_blank">Boyer-Moore String Search Algorithm</a>
+        - <a href="https://www.youtube.com/watch?v=QDZpzctPf10" target="_blank">Advanced String Searching Boyer-Moore-Horspool Algorithms (video)</a>
+    - <a href="https://www.coursera.org/learn/algorithms-on-strings/home/week/1" target="_blank">Coursera: Algorithms on Strings</a>
         - starts off great, but by the time it gets past KMP it gets more complicated than it needs to be
         - nice explanation of tries
         - can be skipped
 
-- **Sorting**
+- <strong>Sorting</strong>
 
     - Stanford lectures on sorting:
-        - [Lecture 15 | Programming Abstractions (video)](https://www.youtube.com/watch?v=ENp00xylP7c&index=15&list=PLFE6E58F856038C69)
-        - [Lecture 16 | Programming Abstractions (video)](https://www.youtube.com/watch?v=y4M9IVgrVKo&index=16&list=PLFE6E58F856038C69)
+        - <a href="https://www.youtube.com/watch?v=ENp00xylP7c&index=15&list=PLFE6E58F856038C69" target="_blank">Lecture 15 | Programming Abstractions (video)</a>
+        - <a href="https://www.youtube.com/watch?v=y4M9IVgrVKo&index=16&list=PLFE6E58F856038C69" target="_blank">Lecture 16 | Programming Abstractions (video)</a>
     - Shai Simonson:
-        - [Algorithms - Sorting - Lecture 2 (video)](https://www.youtube.com/watch?v=odNJmw5TOEE&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=2)
-        - [Algorithms - Sorting II - Lecture 3 (video)](https://www.youtube.com/watch?v=hj8YKFTFKEE&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=3)
+        - <a href="https://www.youtube.com/watch?v=odNJmw5TOEE&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=2" target="_blank">Algorithms - Sorting - Lecture 2 (video)</a>
+        - <a href="https://www.youtube.com/watch?v=hj8YKFTFKEE&list=PLFDnELG9dpVxQCxuD-9BSy2E7BWY3t5Sm&index=3" target="_blank">Algorithms - Sorting II - Lecture 3 (video)</a>
     - Steven Skiena lectures on sorting:
-        - [CSE373 2020 - Mergesort/Quicksort (video)](https://www.youtube.com/watch?v=jUf-UQ3a0kg&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=8)
-        - [CSE373 2020 - Linear Sorting (video)](https://www.youtube.com/watch?v=0ksyQKmre84&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=9)
+        - <a href="https://www.youtube.com/watch?v=jUf-UQ3a0kg&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=8" target="_blank">CSE373 2020 - Mergesort/Quicksort (video)</a>
+        - <a href="https://www.youtube.com/watch?v=0ksyQKmre84&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=9" target="_blank">CSE373 2020 - Linear Sorting (video)</a>
 
-- NAND To Tetris: [Build a Modern Computer from First Principles](https://www.coursera.org/learn/build-a-computer)
+- NAND To Tetris: <a href="https://www.coursera.org/learn/build-a-computer" target="_blank">Build a Modern Computer from First Principles</a>
 
-**[⬆ back to top](#table-of-contents)**
+<strong><a href="#table-of-contents" target="_blank">⬆ back to top</a></strong>
 
-## Video Series
+<h2>Video Series</h2>
 
 Sit back and enjoy.
 
-- [List of individual Dynamic Programming problems (each is short)](https://www.youtube.com/playlist?list=PLrmLmBdmIlpsHaNTPP_jHHDx_os9ItYXr)
+- <a href="https://www.youtube.com/playlist?list=PLrmLmBdmIlpsHaNTPP_jHHDx_os9ItYXr" target="_blank">List of individual Dynamic Programming problems (each is short)</a>
+- <a href="https://www.youtube.com/playlist?list=PL038BE01D3BAEFDB0" target="_blank">x86 Architecture, Assembly, Applications (11 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PLE7DDD91010BC51F8" target="_blank">MIT 18.06 Linear Algebra, Spring 2005 (35 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PL3B08AE665AB9002A" target="_blank">Excellent - MIT Calculus Revisited: Single Variable Calculus</a>
+- <a href="https://www.youtube.com/watch?v=22hwcnXIGgk&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=1" target="_blank">Skiena lectures from Algorithm Design Manual - CSE373 2020 - Analysis of Algorithms (26 videos)</a>
+- <a href="https://archive.org/details/ucberkeley-webcast-PL-XXv-cvA_iAlnI-BQr9hjqADPBtujFJd" target="_blank">UC Berkeley 61B (Spring 2014): Data Structures (25 videos)</a>
+- <a href="https://archive.org/details/ucberkeley-webcast-PL4BBB74C7D2A1049C" target="_blank">UC Berkeley 61B (Fall 2006): Data Structures (39 videos)</a>
+- <a href="https://archive.org/details/ucberkeley-webcast-PL-XXv-cvA_iCl2-D-FS5mk0jFF6cYSJs_" target="_blank">UC Berkeley 61C: Machine Structures (26 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PLJ9pm_Rc9HesnkwKlal_buSIHA-jTZMpO" target="_blank">OOSE: Software Dev Using UML and Java (21 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PLDSlqjcPpoL64CJdF0Qee5oWqGS6we_Yu" target="_blank">MIT 6.004: Computation Structures (49 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PL5PHm2jkkXmi5CxxI7b3JCL1TWybTDtKq" target="_blank">Carnegie Mellon - Computer Architecture Lectures (39 videos)</a>
+- <a href="https://www.youtube.com/watch?v=HtSuA80QTyo&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&nohtml5=False" target="_blank">MIT 6.006: Intro to Algorithms (47 videos)</a>
+- <a href="https://www.youtube.com/watch?v=zm2VP0kHl1M&list=PL6535748F59DCA484" target="_blank">MIT 6.033: Computer System Engineering (22 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PLUl4u3cNGP63gFHB6xb-kVBiQHYe_4hSi" target="_blank">MIT 6.034 Artificial Intelligence, Fall 2010 (30 videos)</a>
+- <a href="https://www.youtube.com/watch?v=L3LMbpZIKhQ&list=PLB7540DEDD482705B" target="_blank">MIT 6.042J: Mathematics for Computer Science, Fall 2010 (25 videos)</a>
+- <a href="https://www.youtube.com/watch?v=2P-yW7LQr08&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp" target="_blank">MIT 6.046: Design and Analysis of Algorithms (34 videos)</a>
+- <a href="https://www.youtube.com/watch?v=cQP8WApzIQQ&list=PLrw6a1wE39_tb2fErI4-WkMbsvGQk9_UB" target="_blank">MIT 6.824: Distributed Systems, Spring 2020 (20 videos)</a>
+- <a href="https://www.youtube.com/watch?v=T0yzrZL1py0&list=PLUl4u3cNGP61hsJNdULdudlRL493b-XZf&index=1" target="_blank">MIT 6.851: Advanced Data Structures (22 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PL6ogFv-ieghdoGKGg2Bik3Gl1glBTEu8c" target="_blank">MIT 6.854: Advanced Algorithms, Spring 2016 (24 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PL2SOU6wwxB0uP4rJgf5ayhHWgw7akUWSf" target="_blank">Harvard COMPSCI 224: Advanced Algorithms (25 videos)</a>
+- <a href="https://www.youtube.com/watch?v=GqmQg-cszw4&index=1&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh" target="_blank">MIT 6.858 Computer Systems Security, Fall 2014</a>
+- <a href="https://www.youtube.com/playlist?list=PL9D558D49CA734A02" target="_blank">Stanford: Programming Paradigms (27 videos)</a>
+- <a href="https://www.youtube.com/playlist?list=PL6N5qY2nvvJE8X75VkXglSrVhLv1tVcfy" target="_blank">Introduction to Cryptography by Christof Paar</a>
+    - <a href="http://www.crypto-textbook.com/" target="_blank">Course Website along with Slides and Problem Sets</a>
+- <a href="https://www.youtube.com/playlist?list=PLLssT5z_DsK9JDLcT8T62VtzwyW9LNepV" target="_blank">Mining Massive Datasets - Stanford University (94 videos)</a>
+- <a href="https://www.youtube.com/user/DrSaradaHerke/playlists?shelf_id=5&view=50&sort=dd" target="_blank">Graph Theory by Sarada Herke (67 videos)</a>
 
-- [x86 Architecture, Assembly, Applications (11 videos)](https://www.youtube.com/playlist?list=PL038BE01D3BAEFDB0)
-
-- [MIT 18.06 Linear Algebra, Spring 2005 (35 videos)](https://www.youtube.com/playlist?list=PLE7DDD91010BC51F8)
-
-- [Excellent - MIT Calculus Revisited: Single Variable Calculus](https://www.youtube.com/playlist?list=PL3B08AE665AB9002A)
-
-- [Skiena lectures from Algorithm Design Manual - CSE373 2020 - Analysis of Algorithms (26 videos)](https://www.youtube.com/watch?v=22hwcnXIGgk&list=PLOtl7M3yp-DX6ic0HGT0PUX_wiNmkWkXx&index=1)
-
-- [UC Berkeley 61B (Spring 2014): Data Structures (25 videos)](https://archive.org/details/ucberkeley-webcast-PL-XXv-cvA_iAlnI-BQr9hjqADPBtujFJd)
-
-- [UC Berkeley 61B (Fall 2006): Data Structures (39 videos)](https://archive.org/details/ucberkeley-webcast-PL4BBB74C7D2A1049C)
-
-- [UC Berkeley 61C: Machine Structures (26 videos)](https://archive.org/details/ucberkeley-webcast-PL-XXv-cvA_iCl2-D-FS5mk0jFF6cYSJs_)
-
-- [OOSE: Software Dev Using UML and Java (21 videos)](https://www.youtube.com/playlist?list=PLJ9pm_Rc9HesnkwKlal_buSIHA-jTZMpO)
-
-- [MIT 6.004: Computation Structures (49 videos)](https://www.youtube.com/playlist?list=PLDSlqjcPpoL64CJdF0Qee5oWqGS6we_Yu)
-
-- [Carnegie Mellon - Computer Architecture Lectures (39 videos)](https://www.youtube.com/playlist?list=PL5PHm2jkkXmi5CxxI7b3JCL1TWybTDtKq)
-
-- [MIT 6.006: Intro to Algorithms (47 videos)](https://www.youtube.com/watch?v=HtSuA80QTyo&list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&nohtml5=False)
-
-- [MIT 6.033: Computer System Engineering (22 videos)](https://www.youtube.com/watch?v=zm2VP0kHl1M&list=PL6535748F59DCA484)
-
-- [MIT 6.034 Artificial Intelligence, Fall 2010 (30 videos)](https://www.youtube.com/playlist?list=PLUl4u3cNGP63gFHB6xb-kVBiQHYe_4hSi)
-
-- [MIT 6.042J: Mathematics for Computer Science, Fall 2010 (25 videos)](https://www.youtube.com/watch?v=L3LMbpZIKhQ&list=PLB7540DEDD482705B)
-
-- [MIT 6.046: Design and Analysis of Algorithms (34 videos)](https://www.youtube.com/watch?v=2P-yW7LQr08&list=PLUl4u3cNGP6317WaSNfmCvGym2ucw3oGp)
-
-- [MIT 6.824: Distributed Systems, Spring 2020 (20 videos)](https://www.youtube.com/watch?v=cQP8WApzIQQ&list=PLrw6a1wE39_tb2fErI4-WkMbsvGQk9_UB)
-
-- [MIT 6.851: Advanced Data Structures (22 videos)](https://www.youtube.com/watch?v=T0yzrZL1py0&list=PLUl4u3cNGP61hsJNdULdudlRL493b-XZf&index=1)
-
-- [MIT 6.854: Advanced Algorithms, Spring 2016 (24 videos)](https://www.youtube.com/playlist?list=PL6ogFv-ieghdoGKGg2Bik3Gl1glBTEu8c)
-
-- [Harvard COMPSCI 224: Advanced Algorithms (25 videos)](https://www.youtube.com/playlist?list=PL2SOU6wwxB0uP4rJgf5ayhHWgw7akUWSf)
-
-- [MIT 6.858 Computer Systems Security, Fall 2014](https://www.youtube.com/watch?v=GqmQg-cszw4&index=1&list=PLUl4u3cNGP62K2DjQLRxDNRi0z2IRWnNh)
-
-- [Stanford: Programming Paradigms (27 videos)](https://www.youtube.com/playlist?list=PL9D558D49CA734A02)
-
-- [Introduction to Cryptography by Christof Paar](https://www.youtube.com/playlist?list=PL6N5qY2nvvJE8X75VkXglSrVhLv1tVcfy)
-    - [Course Website along with Slides and Problem Sets](http://www.crypto-textbook.com/)
-
-- [Mining Massive Datasets - Stanford University (94 videos)](https://www.youtube.com/playlist?list=PLLssT5z_DsK9JDLcT8T62VtzwyW9LNepV)
-
-- [Graph Theory by Sarada Herke (67 videos)](https://www.youtube.com/user/DrSaradaHerke/playlists?shelf_id=5&view=50&sort=dd)
-
-**[⬆ back to top](#table-of-contents)**
+<strong><a href="#table-of-contents" target="_blank">⬆ back to top</a></strong>
 
 ## Computer Science Courses
 
-- [Directory of Online CS Courses](https://github.com/open-source-society/computer-science)
-- [Directory of CS Courses (many with online lectures)](https://github.com/prakhar1989/awesome-courses)
+- <a href="https://github.com/open-source-society/computer-science" target="_blank">Directory of Online CS Courses</a>
+- <a href="https://github.com/prakhar1989/awesome-courses" target="_blank">Directory of CS Courses (many with online lectures)</a>
 
-**[⬆ back to top](#table-of-contents)**
+**<a href="#table-of-contents" target="_blank">⬆ back to top</a>**
 
 ## Algorithms implementation
 
-- [Multiple Algorithms implementation by Princeton University](https://algs4.cs.princeton.edu/code)
+- <a href="https://algs4.cs.princeton.edu/code" target="_blank">Multiple Algorithms implementation by Princeton University</a>
 
-**[⬆ back to top](#table-of-contents)**
+**<a href="#table-of-contents" target="_blank">⬆ back to top</a>**
 
 ## Papers
 
-- [Love classic papers?](https://www.cs.cmu.edu/~crary/819-f09/)
-- [1978: Communicating Sequential Processes](http://spinroot.com/courses/summer/Papers/hoare_1978.pdf)
-    - [implemented in Go](https://godoc.org/github.com/thomas11/csp)
-- [2003: The Google File System](http://static.googleusercontent.com/media/research.google.com/en//archive/gfs-sosp2003.pdf)
+- <a href="https://www.cs.cmu.edu/~crary/819-f09/" target="_blank">Love classic papers?</a>
+- <a href="http://spinroot.com/courses/summer/Papers/hoare_1978.pdf" target="_blank">1978: Communicating Sequential Processes</a>
+    - <a href="https://godoc.org/github.com/thomas11/csp" target="_blank">implemented in Go</a>
+- <a href="http://static.googleusercontent.com/media/research.google.com/en//archive/gfs-sosp2003.pdf" target="_blank">2003: The Google File System</a>
     - replaced by Colossus in 2012
-- [2004: MapReduce: Simplified Data Processing on Large Clusters]( http://static.googleusercontent.com/media/research.google.com/en//archive/mapreduce-osdi04.pdf)
+- <a href="http://static.googleusercontent.com/media/research.google.com/en//archive/mapreduce-osdi04.pdf" target="_blank">2004: MapReduce: Simplified Data Processing on Large Clusters</a>
     - mostly replaced by Cloud Dataflow?
-- [2006: Bigtable: A Distributed Storage System for Structured Data](https://static.googleusercontent.com/media/research.google.com/en//archive/bigtable-osdi06.pdf)
-- [2006: The Chubby Lock Service for Loosely-Coupled Distributed Systems](https://research.google.com/archive/chubby-osdi06.pdf)
-- [2007: Dynamo: Amazon’s Highly Available Key-value Store](http://s3.amazonaws.com/AllThingsDistributed/sosp/amazon-dynamo-sosp2007.pdf)
+- <a href="https://static.googleusercontent.com/media/research.google.com/en//archive/bigtable-osdi06.pdf" target="_blank">2006: Bigtable: A Distributed Storage System for Structured Data</a>
+- <a href="https://research.google.com/archive/chubby-osdi06.pdf" target="_blank">2006: The Chubby Lock Service for Loosely-Coupled Distributed Systems</a>
+- <a href="http://s3.amazonaws.com/AllThingsDistributed/sosp/amazon-dynamo-sosp2007.pdf" target="_blank">2007: Dynamo: Amazon’s Highly Available Key-value Store</a>
     - The Dynamo paper kicked off the NoSQL revolution
-- [2007: What Every Programmer Should Know About Memory (very long, and the author encourages skipping of some sections)](https://www.akkadia.org/drepper/cpumemory.pdf)
+- <a href="https://www.akkadia.org/drepper/cpumemory.pdf" target="_blank">2007: What Every Programmer Should Know About Memory (very long, and the author encourages skipping of some sections)</a>
 - 2012: AddressSanitizer: A Fast Address Sanity Checker:
-    - [paper](http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/37752.pdf)
-    - [video](https://www.usenix.org/conference/atc12/technical-sessions/presentation/serebryany)
+    - <a href="http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/37752.pdf" target="_blank">paper</a>
+    - <a href="https://www.usenix.org/conference/atc12/technical-sessions/presentation/serebryany" target="_blank">video</a>
 - 2013: Spanner: Google’s Globally-Distributed Database:
-    - [paper](http://static.googleusercontent.com/media/research.google.com/en//archive/spanner-osdi2012.pdf)
-    - [video](https://www.usenix.org/node/170855)
-- [2015: Continuous Pipelines at Google](http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/43790.pdf)
-- [2015: High-Availability at Massive Scale: Building Google’s Data Infrastructure for Ads](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/44686.pdf)
-- [2015: How Developers Search for Code: A Case Study](http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/43835.pdf)
-- More papers: [1,000 papers](https://github.com/0voice/computer_expert_paper)
+    - <a href="http://static.googleusercontent.com/media/research.google.com/en//archive/spanner-osdi2012.pdf" target="_blank">paper</a>
+    - <a href="https://www.usenix.org/node/170855" target="_blank">video</a>
+- <a href="http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/43790.pdf" target="_blank">2015: Continuous Pipelines at Google</a>
+- <a href="https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/44686.pdf" target="_blank">2015: High-Availability at Massive Scale: Building Google’s Data Infrastructure for Ads</a>
+- <a href="http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/43835.pdf" target="_blank">2015: How Developers Search for Code: A Case Study</a>
+- More papers: <a href="https://github.com/0voice/computer_expert_paper" target="_blank">1,000 papers</a>
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
I have changed the links in README.md, earlier on clicking the links they would open in the same tab but now they open in the new tab. I changed the markdown format ([text][link]) to HTML <a> tag.

Resolves #2039