### PR TITLE
fix: link to sort methods subtitle in spanish docs

### DIFF
--- a/translations/README-es.md
+++ b/translations/README-es.md
@@ -101,7 +101,7 @@ Si desea ser un Ingeniero de Escalabilidad/Seguridad o un Ingeniero de Sistemas,
     - [Montículo / Colas de Prioridad / Montículo binario](#montículo--colas-de-prioridad--montículo-binario)
     - Árboles de búsqueda balanceables (Concepto General, sin detallar)
     - Recorridos: preorder, inorder, postorder, BFS, DFS
-- [Ordenación](#ordenacion)
+- [Ordenamientos](#ordenamientos)
     - Selección
     - Inserción
     - Por montículos (heapsort)


### PR DESCRIPTION
# Change
- redirect to sort methods section doesn't work in spanish docs because referers to "ordenacion" but subtitle it's "ordenamientos"